### PR TITLE
Deprecated build.image configuration key deleted

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,5 @@
 version: 2
 
-build:
-  image: latest
-
 # Build documentation in the documentation/sphinx/ directory with Sphinx
 sphinx:
   configuration: documentation/sphinx/source/conf.py


### PR DESCRIPTION
* Deleted the deprecated build.image key (Instead of specifying build.os as suggested).