### PR TITLE
[QMI-0.45.0-beta.0] Update the version info to be `-beta.0` for the `main`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.44.0
+current_version = 0.45.0-beta.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?(\.(?P<build>\d+))?

--- a/.github/badges/pylint.svg
+++ b/.github/badges/pylint.svg
@@ -17,7 +17,7 @@
         <text x="22.0" y="14">pylint</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">9.21</text>
-        <text x="62.0" y="14">9.21</text>
+        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">9.22</text>
+        <text x="62.0" y="14">9.22</text>
     </g>
 </svg>

--- a/documentation/sphinx/source/conf.py
+++ b/documentation/sphinx/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2023, QuTech — Delft, The Netherlands'
 author = 'QuTech'
 
 # The full version, including alpha/beta/rc tags
-release = '0.44.0'
+release = '0.45.0-beta.0'
 
 # The default master_doc used to be 'index', but it was changed to 'contents'.
 # Override that here (maybe rename the file to the new default later).

--- a/qmi/__init__.py
+++ b/qmi/__init__.py
@@ -7,7 +7,7 @@ import os
 import atexit
 
 
-__version__ = "0.44.0"
+__version__ = "0.45.0-beta.0"
 
 
 # Check Python version.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read(*names, **kwargs):
 
 setup(
     name='qmi',
-    version='0.44.0',
+    version='0.45.0-beta.0',
     description='The Quantum Measurement Infrastructure framework',
     long_description="{}\n{}".format(
         read('README.md'),


### PR DESCRIPTION
PR for updating the version-revisio info for `main` branch to be the "beta.0" for next release (0.45).