### PR TITLE
[QMI-081] coverage and unit-tests fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - mypy errors not failing pipeline
+- In `instruments.picoquant.support._decoders` made the lexical sorting (`numpy.lexsort`) to temporarily retype the data to signed integer, as from Numpy 2.0 the integers are not allowed anymore to overflow.
+- The same fix is applied also in unit-tests.
 
 ### Removed
 - Radon workflows as radon is no longer actively maintained. Pylint has taken over as the complexity checker.

--- a/qmi/instruments/picoquant/support/_decoders.py
+++ b/qmi/instruments/picoquant/support/_decoders.py
@@ -196,6 +196,10 @@ class _T3EventDecoder(EventDecoder):
         events[num_data_events:]["type"] = 64
         events[num_data_events:]["timestamp"] = sync_timestamps
         # Events need to be sorted by timestamp, and by type number so that sync# 64 is before channel#.
-        events = events[np.lexsort((-1 * events["type"], events["timestamp"]))]
+        # NOTE: Since numpy 2.0 overflow of values is not allowed anymore. Therefore, for the means of the lexical sort
+        # where we use the trick of setting the event types as their negatives to get the right order, now must be
+        # retyped from unsigned 8-bit integer to signed 16-bit integer. The returned array by the lexsort does
+        # re-conform to uint8 when placing it back to `events`, so no errors should be introduced.
+        events = events[np.lexsort((-1 * events["type"].astype("int16"), events["timestamp"]))]
 
         return events


### PR DESCRIPTION
Fix `lexsort` in picoquant decoders support not to cause `OverflowError` as this is not tolerated anymore since NumPy 2.0.