### PR TITLE
90 add   enter   and   exit   methods to qmi instrument

### DIFF
--- a/.github/workflows/reusable-ci-workflows.yml
+++ b/.github/workflows/reusable-ci-workflows.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get update -qy
           sudo apt-get install -y bc
           pip install --upgrade pip
-          pip install -e '.[dev]'
+          pip install '.[dev]'
 
       - name: Run pylint
         run: |

--- a/.github/workflows/scheduled-full-ci.yml
+++ b/.github/workflows/scheduled-full-ci.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Run unit tests and generate report
         if: always()
         run: |
+          pip install -e .
           pip install unittest-xml-reporting
           python -m xmlrunner --output-file testresults.xml discover --start-directory=tests --pattern="test_*.py"
 

--- a/.github/workflows/scheduled-full-ci.yml
+++ b/.github/workflows/scheduled-full-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run unit tests and generate report
         if: always()
         run: |
-          pip install -e .
+          pip install .
           pip install unittest-xml-reporting
           python -m xmlrunner --output-file testresults.xml discover --start-directory=tests --pattern="test_*.py"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[x.y.z] - Unreleased
 
+### Added
+- The `QMI_Instrument` and `QMI_TaskRunner` (which inherit from `QMI_RpcObject`) are now equipped with specific `__enter__` and `__exit__` methods, which in the case of `QMI_Instrument`
+  also open and close the instrument when run with a `with` context manager protocol. Meanwhile `QMI_TaskRunner` starts and stops then joins a QMI task thread. In practise, these context managers
+  can be used instead of the to-be-obsoleted `open_close` and `start_stop_join` context managers. The context manager protocol cannot be used for `QMI_RpcObject` directly.
+
 ### Changed
 - The CI pipelines are now using reusable workflows, placed in reusable-ci-workflows.yml.
 - The file names for the different pipeline actions were also changed to be more descriptive.

--- a/qmi/core/instrument.py
+++ b/qmi/core/instrument.py
@@ -47,7 +47,7 @@ class QMI_Instrument(QMI_RpcObject):
     (measurements, getting and setting of parameters).
 
     Driver should implement a method `reset()` when applicable.
-    This methods returns the instrument to its default settings.
+    This method returns the instrument to its default settings.
 
     Drivers should implement a method `get_idn()` when applicable.
     This method returns an instance of `QMI_InstrumentIdentification`.
@@ -65,6 +65,19 @@ class QMI_Instrument(QMI_RpcObject):
         """
         super().__init__(context, name)
         self._is_open = False
+
+    @rpc_method
+    def __enter__(self) -> "QMI_Instrument":
+        """The `__enter__` methods is decorated as `rpc_method` so that `QMI_RpcProxy` can call it when using the
+        proxy with a `with` context manager. This method also opens the instrument."""
+        self.open()
+        return self
+
+    @rpc_method
+    def __exit__(self, *args, **kwargs) -> None:
+        """The `__exit__` methods is decorated as `rpc_method` so that `QMI_RpcProxy` can call it when using the
+        proxy with a `with` context manager. This method also closes the instrument."""
+        self.close()
 
     def release_rpc_object(self) -> None:
         """Give a warning if the instrument is removed while still open."""

--- a/qmi/core/rpc.py
+++ b/qmi/core/rpc.py
@@ -684,7 +684,8 @@ class QMI_RpcProxy:
         The with keyword checks if the `QMI_RpcProxy` class (not instance) implements the context manager protocol,
         i.e. `__enter__` and `__exit__`, so they exist here as stubs. These stubs make an RPC to the actual `__enter__`
         and `__exit__` methods on the relevant RPC object. If in those classes `__enter__` and `__exit__` are
-        decorated as `rpc_methods`, we do not see a recursion error.
+        decorated as `rpc_methods`, we do not see a recursion error. See for further details in:
+        https://docs.python.org/3/reference/datamodel.html#special-method-lookup
 
         `rpc_method` decorated `__enter__` and `__exit__` methods are currently implemented in `QMI_Instrument` and
         `QMI_TaskRunner` classes.

--- a/qmi/core/task.py
+++ b/qmi/core/task.py
@@ -262,7 +262,7 @@ class QMI_Task(Generic[_SET, _STS], metaclass=_TaskMetaClass):
         to this task, this method copies the new settings to `self.settings`
         and returns True.
 
-        Otherwise the settings remain the same and this method returns False.
+        Otherwise, the settings remain the same and this method returns False.
 
         Returns:
             True if there are new settings, False if the settings are unchanged.
@@ -601,6 +601,19 @@ class QMI_TaskRunner(QMI_RpcObject):
 
         assert state == _TaskThread.State.READY_TO_RUN
         assert self._thread.task is not None
+
+    @rpc_method
+    def __enter__(self):
+        """The `__enter__` methods is decorated as `rpc_method` so that `QMI_RpcProxy` can call it when using the
+        proxy with a `with` context manager. This method also calls to start the task thread."""
+        return self.start()
+
+    @rpc_method
+    def __exit__(self, *args, **kwargs):
+        """The `__exit__` methods is decorated as `rpc_method` so that `QMI_RpcProxy` can call it when using the
+        proxy with a `with` context manager. This method also calls to stop and join the task thread."""
+        self.stop()
+        self.join()
 
     def release_rpc_object(self) -> None:
         """Ensure the task is joined before it is removed from the context."""

--- a/qmi/utils/context_managers.py
+++ b/qmi/utils/context_managers.py
@@ -1,6 +1,7 @@
 """Context managers for QMI RPC protocol contexts."""
 from contextlib import contextmanager
 from typing import Iterator, Optional, Protocol, TypeVar
+import warnings
 
 from qmi.core.pubsub import QMI_SignalReceiver, QMI_SignalSubscriber
 
@@ -47,6 +48,12 @@ def start_stop(thing: _SS, *args, **kwargs) -> Iterator[_SS]:
 
 @contextmanager
 def start_stop_join(thing: _SSJ, *args, **kwargs) -> Iterator[_SSJ]:
+    warnings.warn(
+        "This context manager is obsoleted. The tasks can now by managed directly by their own context manager "
+        "by calling `with qmi.make_task('task_name', TaskClass, args, kwargs) as task: ...`.",
+        DeprecationWarning,
+        stacklevel=3
+    )
     thing.start(*args, **kwargs)
     try:
         yield thing
@@ -57,6 +64,12 @@ def start_stop_join(thing: _SSJ, *args, **kwargs) -> Iterator[_SSJ]:
 
 @contextmanager
 def open_close(thing: _OC) -> Iterator[_OC]:
+    warnings.warn(
+        "This context manager is obsoleted. The instruments can now by managed directly by their own context manager "
+        "by calling `with qmi.make_instrument('instr_name', InstrClass, args, kwargs) as instr: ...`.",
+        DeprecationWarning,
+        stacklevel=3
+    )
     thing.open()
     try:
         yield thing

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -12,7 +12,7 @@ from unittest.mock import sentinel
 
 import qmi
 import qmi.core.exceptions
-from qmi.utils.context_managers import start_stop
+from qmi.utils.context_managers import start_stop, start_stop_join
 from qmi.core.pubsub import QMI_Signal, QMI_SignalReceiver
 from qmi.core.rpc import QMI_RpcObject, rpc_method
 from qmi.core.task import (
@@ -251,8 +251,23 @@ class LoopTestTask(QMI_LoopTask):
 
 
 class TestQMITaskContextManager(unittest.TestCase):
+    """Test the various context managers."""
+    def test_with_context_manager(self):
+        """Test the 'with' context manager run as QMI_TaskRunner."""
+        logging.getLogger("qmi.core.task").setLevel(logging.ERROR)
+        logging.getLogger("qmi.core.rpc").setLevel(logging.ERROR)
+        qmi.start("test-taskrunner")
+        with qmi.make_task(
+            "taskrunner", SimpleTestTask, False, False, 1.0, 2.0
+        ) as task:
+            task.get_status()
+
+        qmi.stop()
+        logging.getLogger("qmi.core.task").setLevel(logging.NOTSET)
+        logging.getLogger("qmi.core.rpc").setLevel(logging.NOTSET)
+
     def test_start_stop_context_manager(self):
-        # Test the context manager run as QMI_TaskRunner
+        """Test the 'start_stop' context manager run as QMI_TaskRunner."""
         logging.getLogger("qmi.core.task").setLevel(logging.ERROR)
         logging.getLogger("qmi.core.rpc").setLevel(logging.ERROR)
         qmi.start("test-taskrunner")
@@ -263,6 +278,21 @@ class TestQMITaskContextManager(unittest.TestCase):
             task.get_status()
 
         task.join()
+        qmi.stop()
+        logging.getLogger("qmi.core.task").setLevel(logging.NOTSET)
+        logging.getLogger("qmi.core.rpc").setLevel(logging.NOTSET)
+
+    def test_start_stop_join_context_manager(self):
+        """Test the 'start_stop_join' context manager run as QMI_TaskRunner."""
+        logging.getLogger("qmi.core.task").setLevel(logging.ERROR)
+        logging.getLogger("qmi.core.rpc").setLevel(logging.ERROR)
+        qmi.start("test-taskrunner2")
+        task: QMI_TaskRunner = qmi.make_task(
+            "taskrunner2", SimpleTestTask, False, False, 1.0, 2.0
+        )
+        with start_stop_join(task):
+            task.get_status()
+
         qmi.stop()
         logging.getLogger("qmi.core.task").setLevel(logging.NOTSET)
         logging.getLogger("qmi.core.rpc").setLevel(logging.NOTSET)
@@ -281,7 +311,72 @@ class TestQMITasks(unittest.TestCase):
         logging.getLogger("qmi.core.task").setLevel(logging.NOTSET)
         logging.getLogger("qmi.core.rpc").setLevel(logging.NOTSET)
 
+    def test_context_manager(self):
+        """Test the 'with' context manager does the same as start_stop_join context manager."""
+        with qmi.make_task(
+                "simple_task_init",
+                SimpleTestTask,
+                raise_exception_in_init=False,
+                raise_exception_in_run=False,
+                duration=1.0,
+                value=5,
+        ) as simple_task:
+            self.assertTrue(simple_task.is_running())
+
+        self.assertFalse(simple_task.is_running())
+
+    def test_exception_double_start(self):
+        """Test QMI_UsageException is raised if the task is started twice."""
+        with self.assertRaises(qmi.core.exceptions.QMI_UsageException):
+            task_proxy = qmi.make_task(
+                "simple_task_init",
+                SimpleTestTask,
+                raise_exception_in_init=False,
+                raise_exception_in_run=False,
+                duration=1.0,
+                value=5,
+            )
+            task_proxy.start()
+            task_proxy.start()
+
+        # Remove task proxy and re-run within context manager.
+        qmi.context().remove_rpc_object(task_proxy)
+
+        with self.assertRaises(qmi.core.exceptions.QMI_UsageException):
+            with qmi.make_task(
+                "simple_task_init",
+                SimpleTestTask,
+                raise_exception_in_init=False,
+                raise_exception_in_run=False,
+                duration=1.0,
+                value=5,
+            ) as task_proxy:
+                task_proxy.start()
+
+    def test_exception_duplicate_task(self):
+        """Test QMI_UsageException is raised if the task is created twice."""
+        task_proxy = qmi.make_task(
+            "simple_task_init",
+            SimpleTestTask,
+            raise_exception_in_init=False,
+            raise_exception_in_run=False,
+            duration=1.0,
+            value=5,
+        )
+
+        with self.assertRaises(qmi.core.exceptions.QMI_DuplicateNameException):
+            with qmi.make_task(
+                "simple_task_init",
+                SimpleTestTask,
+                raise_exception_in_init=False,
+                raise_exception_in_run=False,
+                duration=1.0,
+                value=5,
+            ) as task_proxy:
+                pass
+
     def test_exception_during_init(self):
+        """Test QMI_TaskInitException is raised."""
         with self.assertRaises(qmi.core.exceptions.QMI_TaskInitException):
             qmi.make_task(
                 "simple_task_init",
@@ -293,6 +388,7 @@ class TestQMITasks(unittest.TestCase):
             )
 
     def test_exception_during_run(self):
+        """Test QMI_TaskRunException is raised."""
         task_proxy = qmi.make_task(
             "simple_task_run",
             SimpleTestTask,
@@ -306,7 +402,23 @@ class TestQMITasks(unittest.TestCase):
         with self.assertRaises(qmi.core.exceptions.QMI_TaskRunException):
             task_proxy.join()
 
+    def test_exception_during_context_run(self):
+        """Test QMI_TaskRunException is raised within context."""
+        with self.assertRaises(qmi.core.exceptions.QMI_TaskRunException):
+            with qmi.make_task(
+                "simple_task_run",
+                SimpleTestTask,
+                raise_exception_in_init=False,
+                raise_exception_in_run=True,
+                duration=1.0,
+                value=6,
+            ) as task_proxy:
+                time.sleep(2.0)
+
+        self.assertFalse(task_proxy.is_running())
+
     def test_run_to_completion(self):
+        """Test task stops running after completion of the task."""
         task_proxy = qmi.make_task(
             "simple_task_complete",
             SimpleTestTask,
@@ -328,6 +440,7 @@ class TestQMITasks(unittest.TestCase):
         self.assertEqual(status, 7)
 
     def test_run_to_stopped(self):
+        """Test task stops running if it is called to stop."""
         task_proxy = qmi.make_task(
             "simple_task_stopped",
             SimpleTestTask,
@@ -352,7 +465,53 @@ class TestQMITasks(unittest.TestCase):
         status = task_proxy.get_status()
         self.assertIsNone(status)
 
+    def test_context_run_to_completion(self):
+        """Test task stops running after completion of the task within context manager."""
+        with qmi.make_task(
+            "simple_task_complete",
+            SimpleTestTask,
+            raise_exception_in_init=False,
+            raise_exception_in_run=False,
+            duration=1.0,
+            value=7,
+        ) as task_proxy:
+            self.assertTrue(task_proxy.is_running())
+            time.sleep(2.0)
+            self.assertFalse(task_proxy.is_running())
+            t1 = time.monotonic()
+
+        t2 = time.monotonic()
+        self.assertLess(t2 - t1, 0.1)
+        status = task_proxy.get_status()
+        self.assertEqual(status, 7)
+
+    def test_context_run_to_stopped(self):
+        """Test task stops running within context manager if it is called to stop."""
+        with qmi.make_task(
+            "simple_task_stopped",
+            SimpleTestTask,
+            raise_exception_in_init=False,
+            raise_exception_in_run=False,
+            duration=2.0,
+            value=8,
+        ) as task_proxy:
+            time.sleep(0.5)
+            self.assertTrue(task_proxy.is_running())
+            t1 = time.monotonic()
+            task_proxy.stop()
+            t2 = time.monotonic()
+            self.assertLess(t2 - t1, 0.1)
+            time.sleep(0.1)
+            self.assertFalse(task_proxy.is_running())
+            t1 = time.monotonic()
+
+        t2 = time.monotonic()
+        self.assertLess(t2 - t1, 0.1)
+        status = task_proxy.get_status()
+        self.assertIsNone(status)
+
     def test_update_settings(self):
+        """Test updating task settings."""
         task_proxy = qmi.make_task(
             "simple_task_update",
             SimpleTestTask,
@@ -379,7 +538,36 @@ class TestQMITasks(unittest.TestCase):
         self.assertEqual(status, 101)
         self.assertEqual(settings_received, new_settings)
 
+    def test_update_settings_with_context(self):
+        """Test updating task settings within a context manager."""
+        recv = QMI_SignalReceiver()
+        with qmi.make_task(
+            "simple_task_update",
+            SimpleTestTask,
+            raise_exception_in_init=False,
+            raise_exception_in_run=False,
+            duration=2.0,
+            value=9,
+        ) as task_proxy:
+            task_proxy.sig_settings_updated.subscribe(recv)
+            time.sleep(0.5)
+            old_settings = task_proxy.get_settings()
+            new_settings = SimpleTestTask.Settings("hello", 101)
+            task_proxy.set_settings(new_settings)
+            time.sleep(0.5)
+            active_settings = task_proxy.get_settings()
+            task_proxy.join()
+            status = task_proxy.get_status()
+            settings_received = recv.get_next_signal().args[0]
+
+        self.assertNotEqual(old_settings, active_settings)
+        self.assertEqual(active_settings, new_settings)
+        self.assertEqual(status, 101)
+        self.assertEqual(settings_received, new_settings)
+
     def test_get_pending_settings(self):
+        """A more complex test to obtain pending settings for slow cycle tasks, where the new settings are not updated
+        frequently."""
         event = threading.Event()
         task_proxy = qmi.make_task(
             "slow_task", SlowTestTask, duration=2.0, value=9, event=event
@@ -407,7 +595,36 @@ class TestQMITasks(unittest.TestCase):
         self.assertEqual(pending_settings, new_settings)
         self.assertIsNone(post_pending_settings)
 
+    def test_get_pending_settings_with_context(self):
+        """A more complex test to obtain pending settings for slow cycle tasks, where the new settings are not updated
+        frequently, within a context manager."""
+        event = threading.Event()
+        recv = QMI_SignalReceiver()
+        with qmi.make_task(
+            "slow_task", SlowTestTask, duration=2.0, value=9, event=event
+        ) as task_proxy:
+            task_proxy.sig_settings_updated.subscribe(recv)
+            pre_pending_settings = task_proxy.get_pending_settings()
+            new_settings = SimpleTestTask.Settings("hello", 101)
+            # When setting new settings with QMI_TaskRunner.set_settings the new settings are put into a FiFo queue.
+            task_proxy.set_settings(new_settings)
+            # The settings won't be updated in the proxy before update_settings() has been called in a LoopTask
+            # instance. This triggers obtaining the next item in the FiFo queue.
+            # In the run() of SlowTestTask class, update_settings() called only after the event is set.
+            pending_settings = task_proxy.get_pending_settings()
+            event.set()
+            time.sleep(0.4)
+            self.assertIsNone(task_proxy.get_pending_settings())
+            event.set()
+            time.sleep(0.4)
+            post_pending_settings = task_proxy.get_pending_settings()
+
+        self.assertIsNone(pre_pending_settings)
+        self.assertEqual(pending_settings, new_settings)
+        self.assertIsNone(post_pending_settings)
+
     def test_signals(self):
+        """Test the published signal in task gets added to the queue and received correctly."""
         task_proxy = qmi.make_task(
             "simple_task_signals",
             SimpleTestTask,
@@ -430,6 +647,7 @@ class TestQMITasks(unittest.TestCase):
         self.assertEqual(sig.args, (10,))
 
     def test_stop_before_start(self):
+        """Test that just making a task doesn't start it, but also does not fail if `stop()` or `join()` is called."""
         task_proxy = qmi.make_task(
             "simple_task_stop",
             SimpleTestTask,
@@ -450,6 +668,7 @@ class TestQMITasks(unittest.TestCase):
         self.assertIsNone(status)
 
     def test_receive_signals(self):
+        """Test that signals are received one cycle (0.1s) after sending, and that the task stops at -1."""
         publisher_proxy = qmi.context().make_rpc_object("test_publisher", TestPublisher)
         task_proxy = qmi.make_task(
             "receiving_task",
@@ -474,7 +693,33 @@ class TestQMITasks(unittest.TestCase):
         self.assertFalse(task_proxy.is_running())
         task_proxy.join()
 
+    def test_receive_signals_in_context(self):
+        """Test that signals are received one cycle (0.1s) after sending within a context manager."""
+        publisher_proxy = qmi.context().make_rpc_object("test_publisher", TestPublisher)
+        with qmi.make_task(
+            "receiving_task",
+            SignalWaitingTask,
+            wait_timeout=None,
+            context_id=self._ctx_qmi_id,
+        ) as task_proxy:
+            self.assertTrue(task_proxy.is_running())
+            time.sleep(0.1)
+            status = task_proxy.get_status()
+            self.assertIsNone(status)
+            publisher_proxy.send_signal(8)
+            time.sleep(0.1)
+            status = task_proxy.get_status()
+            self.assertEqual(status, 8)
+            publisher_proxy.send_signal(9)
+            time.sleep(0.1)
+            status = task_proxy.get_status()
+            self.assertEqual(status, 9)
+            publisher_proxy.send_signal(-1)
+            time.sleep(0.1)
+            self.assertFalse(task_proxy.is_running())
+
     def test_timeout_while_waiting_for_signal(self):
+        """Test when a wait times out, it raises an exception."""
         qmi.context().make_rpc_object("test_publisher", TestPublisher)
         task_proxy = qmi.make_task(
             "receiving_task",
@@ -492,6 +737,24 @@ class TestQMITasks(unittest.TestCase):
         # task will have raised a QMI_TimeoutException while waiting for a signal
         with self.assertRaises(qmi.core.exceptions.QMI_TaskRunException):
             task_proxy.join()
+
+    def test_timeout_while_waiting_for_signal_in_context(self):
+        """Test when a wait times out, it raises an exception within a context manager."""
+        qmi.context().make_rpc_object("test_publisher", TestPublisher)
+        # task will have raised a QMI_TimeoutException while waiting for a signal
+        with self.assertRaises(qmi.core.exceptions.QMI_TaskRunException):
+            with qmi.make_task(
+                "receiving_task",
+                SignalWaitingTask,
+                wait_timeout=1.0,
+                context_id=self._ctx_qmi_id,
+            ) as task_proxy:
+                time.sleep(0.1)
+                self.assertTrue(task_proxy.is_running())
+                time.sleep(1.4)
+                self.assertFalse(task_proxy.is_running())
+                status = task_proxy.get_status()
+                self.assertEqual(status, -101)  # indicates task got QMI_TimeoutException
 
     def test_stop_while_waiting_for_signal(self):
         qmi.context().make_rpc_object("test_publisher", TestPublisher)
@@ -514,7 +777,6 @@ class TestQMITasks(unittest.TestCase):
     def test_run_to_loop_finish(self):
         """Test and assert that loop runs normally from start to finish if there are no glitches."""
         # Arrange
-
         status_signals_received = []
         settings_signals_received = []
         nr_of_loops = 3
@@ -561,7 +823,57 @@ class TestQMITasks(unittest.TestCase):
             time.sleep(0.1 * loop_period)
 
         status_signals_received.append(task_proxy.get_status().value)
-        time.sleep(2 * loop_period)  # Give time to finalize
+        task_proxy.join()  # Give time to finalize
+        # Assert
+        self.assertListEqual(status_signals_expected, status_signals_received)
+        self.assertListEqual(settings_signals_expected, settings_signals_received)
+        self.assertFalse(task_proxy.is_running())
+
+    def test_run_to_loop_finish_in_context(self):
+        """Test and assert that loop runs normally within context manager if there are no glitches."""
+        # Arrange
+        status_signals_received = []
+        settings_signals_received = []
+        nr_of_loops = 3
+        increase_loop = False
+        initial_status_value = -1
+        loop_period = 0.1
+        policy = QMI_LoopTaskMissedLoopPolicy.IMMEDIATE
+        status_signals_expected = list(range(initial_status_value, nr_of_loops, 1)) + [1]
+        settings_signals_expected = list(range(1, 4))
+        receiver = QMI_SignalReceiver()
+
+        with qmi.make_task(
+            "loop_task_finish2",
+            LoopTestTask,
+            increase_loop=increase_loop,
+            nr_of_loops=nr_of_loops,
+            status_value=initial_status_value,
+            loop_period=loop_period,
+            policy=policy,
+        ) as task_proxy:
+            # Act
+            publisher_proxy = qmi.get_task(f"{self._ctx_qmi_id}.loop_task_finish2")
+            publisher_proxy.sig_settings_updated.subscribe(receiver)
+            # Test that prepare has done its job
+            status_signals_received.append(task_proxy.get_status().value)
+            # LoopTestTask does 3x 1 second loops --> should be finished after 3 seconds
+            for n in range(nr_of_loops):
+                # Test that the status changes at the end of each loop, after receiver signal increments
+                while task_proxy.get_status().value == status_signals_received[-1]:
+                    time.sleep(0.1 * loop_period)
+
+                settings_signals_received.append(
+                    receiver.get_next_signal(timeout=2 * loop_period).args[-1]
+                )
+                status_signals_received.append(task_proxy.get_status().value)
+
+            # Test that finalize_loop sets status back to 1
+            while task_proxy.get_status().value == status_signals_received[-1]:
+                time.sleep(0.1 * loop_period)
+
+            status_signals_received.append(task_proxy.get_status().value)
+
         # Assert
         self.assertListEqual(status_signals_expected, status_signals_received)
         self.assertListEqual(settings_signals_expected, settings_signals_received)


### PR DESCRIPTION
- The `QMI_Instrument` and `QMI_TaskRunner` (which inherit from `QMI_RpcObject`) are now equipped with specific `__enter__` and `__exit__` methods, which in the case of `QMI_Instrument`
  also open and close the instrument when run with a `with` context manager protocol. Meanwhile `QMI_TaskRunner` starts and stops then joins a QMI task thread. In practise, these context managers
  can be used instead of the to-be-obsoleted `open_close` and `start_stop_join` context managers. The context manager protocol cannot be used for `QMI_RpcObject` directly.

- Relevant unit-tests added
- Docstrings added and improved.

- Fix on scheduled full CI unit-test pipeline which was missing installing of dependencies.