### PR TITLE
Add rtscts keyword to TransportDescriptorParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Improved PicoQuant unit-testing modules and comment line fixes on some other modules.
 - Bug in Newport Single Axis Motion Controller that did not allow for negative relative moves.
+- Implemented the rtscts keyword in TransportDescriptorParser for the (serial) transport factory.
 
 ## [0.43.0] - 2023-11-23
 

--- a/qmi/core/transport.py
+++ b/qmi/core/transport.py
@@ -293,6 +293,10 @@ class TransportDescriptorParser:
                     ty = self._keywords[k][0]
                     if ty is int and v.startswith('0x'):
                         parameters[k] = int(v, 16)
+                    elif ty == bool:
+                        if v not in ("True", "False"):
+                            raise ValueError()
+                        parameters[k] = (v == "True")
                     else:
                         parameters[k] = ty(v)
                 except ValueError:
@@ -318,7 +322,8 @@ SerialTransportDescriptorParser = TransportDescriptorParser(
     [("device", (str, True))],
     {'baudrate': (int, False), 'bytesize': (int, False),
      'parity': (str, False),
-     'stopbits': (float, False)}
+     'stopbits': (float, False),
+     'rtscts': (bool, False)}
 )
 
 TcpTransportDescriptorParser = TransportDescriptorParser(
@@ -400,6 +405,7 @@ class QMI_SerialTransport(QMI_Transport):
         self._validate_bytesize(bytesize)
         self._validate_parity(parity)
         self._validate_stopbits(stopbits)
+        self._validate_rstcts(rtscts)
 
         self.device = device
         self._baudrate = baudrate
@@ -434,6 +440,11 @@ class QMI_SerialTransport(QMI_Transport):
     def _validate_device_name(device: str) -> None:
         if not (device.upper().startswith("COM") or device.startswith("/")):
             raise QMI_TransportDescriptorException("Unknown serial port device path ({})".format(device))
+
+    @staticmethod
+    def _validate_rstcts(rtscts: bool) -> None:
+        if rtscts not in (True, False):
+            raise QMI_TransportDescriptorException("Invalid rtscts ({})".format(rtscts))
 
     @property
     def _safe_serial(self) -> serial.Serial:

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -96,12 +96,13 @@ class TestQmiTransportFactory(unittest.TestCase):
 
     @unittest.mock.patch("qmi.core.transport.QMI_SerialTransport")
     def test_factory_serial_attributes(self, mock):
-        trans = create_transport("serial:COM3:baudrate=115200:bytesize=7:parity=E:stopbits=2")
+        trans = create_transport("serial:COM3:baudrate=115200:bytesize=7:parity=E:stopbits=2:rtscts=True")
         self.assertIs(trans, mock.return_value)
         mock.assert_called_once_with(device="COM3",
                                      baudrate=115200,
                                      bytesize=7,
                                      parity="E",
+                                     rtscts=True,
                                      stopbits=2)
 
     def test_factory_udp(self):
@@ -164,13 +165,14 @@ class TestQmiTransportFactory(unittest.TestCase):
 
     @unittest.mock.patch("qmi.core.transport.QMI_SerialTransport")
     def test_parse_serial_attrs(self, mock):
-        trans = create_transport("serial:COM3:baudrate=120:bytesize=7:parity=E:stopbits=1.5")
+        trans = create_transport("serial:COM3:baudrate=120:bytesize=7:parity=E:stopbits=1.5:rtscts=True")
         self.assertIs(trans, mock.return_value)
         mock.assert_called_once_with(device="COM3",
                                      baudrate=120,
                                      bytesize=7,
                                      parity="E",
-                                     stopbits=1.5)
+                                     stopbits=1.5,
+                                     rtscts=True)
 
     @unittest.mock.patch("qmi.core.transport.QMI_SerialTransport")
     def test_parse_serial_defaults(self, mock):
@@ -178,17 +180,23 @@ class TestQmiTransportFactory(unittest.TestCase):
                                  {"baudrate": 115200,
                                   "bytesize": 8,
                                   "parity": "N",
-                                  "stopbits": 1.0})
+                                  "stopbits": 1.0,
+                                  "rtscts": False})
         self.assertIs(trans, mock.return_value)
         mock.assert_called_once_with(device="/dev/ttyUSB0",
                                      baudrate=115200,
                                      bytesize=8,
                                      parity="N",
-                                     stopbits=1.0)
+                                     stopbits=1.0,
+                                     rtscts=False)
 
     def test_parse_serial_bad_attrtype(self):
         with self.assertRaises(qmi.core.exceptions.QMI_TransportDescriptorException):
             create_transport("serial:/dev/ttyS0:baudrate=fast")
+
+    def test_parse_serial_bad_booltype(self):
+        with self.assertRaises(qmi.core.exceptions.QMI_TransportDescriptorException):
+            create_transport("serial:/dev/ttyS0:baudrate=115200:rtscts=0")
 
     def test_parse_serial_bad_attrname(self):
         with self.assertRaises(qmi.core.exceptions.QMI_TransportDescriptorException):
@@ -1152,6 +1160,7 @@ class TestQmiSerialTransportInit(unittest.TestCase):
         QMI_SerialTransport("/valid/path", 9600)
         QMI_SerialTransport("COM3", 120, bytesize=7, parity="E", stopbits=1.5)
         QMI_SerialTransport("/dev/ttyUSB0", 115200, bytesize=8, parity="N", stopbits=1.0)
+        QMI_SerialTransport("/dev/ttyUSB0", 115200, bytesize=8, parity="N", stopbits=1.0, rtscts=True)
 
     def test_invalid_device_description(self):
         with self.assertRaises(qmi.core.exceptions.QMI_TransportDescriptorException):
@@ -1176,6 +1185,10 @@ class TestQmiSerialTransportInit(unittest.TestCase):
     def test_invalid_stopbits(self):
         with self.assertRaises(qmi.core.exceptions.QMI_TransportDescriptorException):
             QMI_SerialTransport("/valid/path", 9600, stopbits=1.4)
+
+    def test_invalid_rtscts(self):
+        with self.assertRaises(qmi.core.exceptions.QMI_TransportDescriptorException):
+            QMI_SerialTransport("/valid/path", 9600, rtscts=3.14)
 
     @unittest.mock.patch("qmi.core.transport.serial.Serial", autospec=True)
     def test_correct_open_close(self, mocked_serial):

--- a/tests/instruments/thorlabs/test_mff10x.py
+++ b/tests/instruments/thorlabs/test_mff10x.py
@@ -161,7 +161,7 @@ class TestThorlabsMFF10x(unittest.TestCase):
                 baudrate=self.baudrate,  # The rest are defaults
                 bytesize=8,
                 parity='N',
-                rtscts=False,
+                rtscts=True,
                 stopbits=1.0,
                 timeout=0.04
                 )


### PR DESCRIPTION
Added a proper case for bool type in the parser (otherwise any non-empty string would evaluate to True).