### PR TITLE
121 unit tests failing for the weekly full ci

### DIFF
--- a/.github/workflows/reusable-ci-workflows.yml
+++ b/.github/workflows/reusable-ci-workflows.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run coverage
         run: |
           if [[ ${{ inputs.python-version }} == "3.13" ]]; \
-            then pip install https://github.com/da4089/py-xdrlib/archive/refs/heads/main.zip; fi
+            then pip install py-xdrlib; fi
           coverage run --branch --source=$SOURCE_DIRS -m unittest discover --start-directory=tests --pattern="test_*.py"
           coverage report --show-missing --fail-under=$COVERAGE_MIN_PERC | tee coverage-${{ inputs.python-version }}.log
           COVERAGE_PERC=$(grep "TOTAL" coverage-${{ inputs.python-version }}.log | grep -Eo '[0-9.]+%' | sed 's/%//')

--- a/.github/workflows/scheduled-full-ci.yml
+++ b/.github/workflows/scheduled-full-ci.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     # Schedule for every Monday at 7am
     - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run workflow on'
+        required: true
+        default: 'main'
 
 jobs:
   full-test:
@@ -24,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.event.inputs.branch || inputs.ref }}
 
       - name: Check py-xdrlib installation for Python 3.13
         if: ${{ matrix.python-version }} == "3.13"

--- a/.github/workflows/scheduled-full-ci.yml
+++ b/.github/workflows/scheduled-full-ci.yml
@@ -28,13 +28,13 @@ jobs:
 
       - name: Check py-xdrlib installation for Python 3.13
         if: ${{ matrix.python-version }} == "3.13"
-        run: pip install py-xdrlib
+        run: python -m pip install py-xdrlib
 
       - name: Run unit tests and generate report
         if: always()
         run: |
-          pip install .
-          pip install unittest-xml-reporting
+          python -m pip install .
+          python -m pip install unittest-xml-reporting
           python -m xmlrunner --output-file testresults.xml discover --start-directory=tests --pattern="test_*.py"
 
       - name: Upload unit test results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ qmi_wieserlabs_flexdds = "bin.instruments.qmi_wieserlabs_flexdds:main"
 
 [tool.setuptools]
 include-package-data = true
-zip-safe = false
 
 [tool.setuptools.packages.find]
 where = ["qmi/"]


### PR DESCRIPTION
Trying to fix the issue with actually using local pip install of the `qmi` with `python -m pip install .`, because the `[build-system]` section was already present so that was not the issue.

For running the `full-ci` manually to test at will, instead of waiting until next monday, I added in the `scheduled-full-ci.yml` at the start a `workflow_dispatch` subsection:
```yaml
on:
  schedule:
    # Schedule for every Monday at 7am
    - cron: "0 7 * * 1"
  workflow_dispatch:
    inputs:
      branch:
        description: 'Branch to run workflow on'
        required: true
        default: 'main'
```

and extending
```yaml
        with:
          ref: ${{ inputs.ref }}
```

with
```yaml
        with:
          ref: ${{ github.event.inputs.branch || inputs.ref }}
```

When this is merged in `main`, it should be possible to run the full CI test also manually on a selected branch.
