### PR TITLE
125 new mypy issues to fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `qmi_tool` script entry point to be at `main` function.
 - Package management to be done via `pyproject.toml` instead of `setup.py`.
+- Digilent and PicoTech devices' typing fixed and modernized.
 
 ### Fixed
 - Full CI-test to install qmi package correctly and run unit-tests with all supported Python versions.

--- a/qmi/instruments/digilent/__init__.py
+++ b/qmi/instruments/digilent/__init__.py
@@ -1,5 +1,5 @@
 """
-Digilent, USB oscilloscope device.
+Digilent, USB oscilloscope and logic analyzer device.
 
 The qmi.instruments.digilent package provides support for:
 - Analog Discovery 2 device.

--- a/qmi/instruments/digilent/analog_discovery.py
+++ b/qmi/instruments/digilent/analog_discovery.py
@@ -383,4 +383,4 @@ class AnalogDiscovery2(QMI_Instrument):
         except pydwf.DwfLibraryError as library_error:
             raise QMI_InstrumentException(str(library_error)) from library_error
 
-        return sample_record.tolist()
+        return list(sample_record)

--- a/qmi/instruments/digilent/analog_discovery.py
+++ b/qmi/instruments/digilent/analog_discovery.py
@@ -352,7 +352,7 @@ class AnalogDiscovery2(QMI_Instrument):
             raise QMI_UsageException("Device should be opened before use.")
 
         analog_in = self._device.analogIn
-        sample_record: np.ndarray = np.array([])
+        sample_record: np._typing.NDArray[np.float64] = np.array([])
         try:
             if amount_samples is None:
                 amount_samples_rational = analog_in.recordLengthGet() // analog_in.frequencyGet()

--- a/qmi/instruments/digilent/analog_discovery.py
+++ b/qmi/instruments/digilent/analog_discovery.py
@@ -1,10 +1,8 @@
-"""QMI driver for the Digilent Analog Discovery 2 board.
-"""
+"""QMI driver for the Digilent Analog Discovery 2 board."""
+
 import logging
 import time
-import typing
 from enum import Enum
-from typing import Optional
 
 import numpy as np
 import pydwf
@@ -37,13 +35,12 @@ class Filter(Enum):
 
 
 class AnalogDiscovery2(QMI_Instrument):
-    """QMI driver for the Analog Discovery 2 board.
-    """
+    """QMI driver for the Analog Discovery 2 board."""
 
     def __init__(self, context: QMI_Context, name: str, serial_number: str) -> None:
         super().__init__(context, name)
         self._serial_number = serial_number
-        self._device = None  # type: Optional[pydwf.core.dwf_device.DwfDevice]
+        self._device: pydwf.core.dwf_device.DwfDevice | None = None
 
     @rpc_method
     def open(self) -> None:
@@ -54,6 +51,15 @@ class AnalogDiscovery2(QMI_Instrument):
         super().open()
 
     def _open_device(self, dwf: DwfLibrary) -> pydwf.core.dwf_device.DwfDevice:
+        """Try to open the device for control.
+
+        Returns:
+            DwfDevice:               An opened DWF device instance.
+
+        Raises:
+            QMI_InstrumentException: If an error was reported by the 'openDwfDevice' DWF C library function.
+            ValueError:              Any error in pydwf caused by the underlying C API or otherwise.
+        """
         try:
             return pydwf.utilities.openDwfDevice(dwf, serial_number_filter=self._serial_number)
         except pydwf.DwfLibraryError as library_error:
@@ -83,15 +89,15 @@ class AnalogDiscovery2(QMI_Instrument):
 
     @rpc_method
     def prepare_analog_output_channel_for_static_output(self, channel: int, voltage: float) -> None:
-        """Prepare analog output channel for static output
+        """Prepare analog output channel for static output.
 
-        Arguments:
-            channel: channel to prepare for static output
-            voltage: initial voltage
+        Parameters:
+            channel: Channel to prepare for static output.
+            voltage: Initial voltage.
 
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_InstrumentException: QMI_InstrumentException is raised when an unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_InstrumentException: Raised when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -107,15 +113,15 @@ class AnalogDiscovery2(QMI_Instrument):
 
     @rpc_method
     def set_analog_output_voltage_output(self, channel: int, voltage: float) -> None:
-        """Set analog output to a desired voltage
+        """Set analog output channel to a target voltage.
 
-        Arguments:
-            channel: desired channel
-            voltage: desired voltage level
+        Parameters:
+            channel: Target channel.
+            voltage: Target voltage level.
 
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_InstrumentException: QMI_InstrumentException is raised when an unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_InstrumentException: Raised when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -127,17 +133,17 @@ class AnalogDiscovery2(QMI_Instrument):
 
     @rpc_method
     def get_analog_output_voltage_output(self, channel: int) -> float:
-        """Get the set voltage level for the analog output
+        """Get the set voltage level for the analog output.
 
-        Arguments:
-            channel: the desired channel to query.
+        Parameters:
+            channel:          The target channel to query.
 
         Returns:
-            The set voltage level of the specified channel.
+            voltage_setpoint: The set voltage level of the specified channel.
 
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_InstrumentException: QMI_InstrumentException is raised when an unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_InstrumentException: Raised when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -151,14 +157,14 @@ class AnalogDiscovery2(QMI_Instrument):
 
     @rpc_method
     def set_device_on_close(self, on_close: OnClose) -> None:
-        """Set on close behaviour
+        """Set on close behaviour.
 
-        Arguments:
+        Parameters:
             on_close: OnClose enum: either CONTINUE, STOP or SHUTDOWN after closing the device.
 
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_InstrumentException: QMI_InstrumentException is raised when an unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_InstrumentException: Raised when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -172,10 +178,9 @@ class AnalogDiscovery2(QMI_Instrument):
     def reset_analog_input(self):
         """Resets and configures analog input parameters to default values.
 
-
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_InstrumentException: QMI_InstrumentException is raised when an unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_InstrumentException: Raised when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -187,28 +192,31 @@ class AnalogDiscovery2(QMI_Instrument):
             raise QMI_InstrumentException(str(library_error)) from library_error
 
     @rpc_method
-    def prepare_analog_input_sample(self,
-                                    channel: int,
-                                    voltage_range: float,
-                                    acquisition_frequency: float,
-                                    adc_filter: Filter = Filter.AVERAGE,
-                                    voltage_offset: float = 0.0,
-                                    buffer_size: Optional[int] = None) -> None:
+    def prepare_analog_input_sample(
+        self,
+        channel: int,
+        voltage_range: float,
+        acquisition_frequency: float,
+        adc_filter: Filter = Filter.AVERAGE,
+        voltage_offset: float = 0.0,
+        buffer_size: int | None = None
+    ) -> None:
         """Prepare readout voltage on specified channel.
 
-        Args:
-            channel: The channel to prepare.
-            voltage_offset: Offset in volts.
-            voltage_range: Range in voltage defined as peak to peak value centered around the offset value.
+        Parameters:
+            channel:               The channel to prepare.
+            voltage_offset:        Offset in volts.
+            voltage_range:         Range in voltage defined as peak to peak value centered around the offset value.
             acquisition_frequency: Acquisition frequency in Hz. The device samples ADC operates at 100 MHz.
-                If an acquisition frequency lower than 100 MHz is provided. The samples will be filtered using the
-                provided filter rule. Note that the acquisition is set for both channels.
-            adc_filter: Filter rule to apply to ADC samples. See analog_discovery.Filter for documentation.
-            buffer_size: Adjust the buffer size of the analog in instrument: 16 <= buffer_size <= 8192.
+                                   If an acquisition frequency lower than 100 MHz is provided. The samples will be
+                                   filtered using the provided filter rule.
+                                   Note that the acquisition is set for both channels.
+            adc_filter:            Filter rule to apply to ADC samples. See analog_discovery.Filter for documentation.
+            buffer_size:           Adjust the buffer size of the analog in instrument: 16 <= buffer_size <= 8192.
 
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_InstrumentException: QMI_InstrumentException is raised when an unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_InstrumentException: Raised when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -216,16 +224,17 @@ class AnalogDiscovery2(QMI_Instrument):
         analog_in = self._device.analogIn
         try:
             analog_in.channelEnableSet(channel, True)
-
             analog_in.frequencySet(acquisition_frequency)
             if buffer_size is not None:
                 analog_in.bufferSizeSet(buffer_size)
+
             analog_in.channelOffsetSet(channel, channel_offset=voltage_offset)
             analog_in.channelRangeSet(channel, channel_range=voltage_range)
             analog_in.channelFilterSet(channel, pydwf.DwfAnalogInFilter(adc_filter.value))
             analog_in.configure(False, False)
         except pydwf.DwfLibraryError as library_error:
             raise QMI_InstrumentException(str(library_error)) from library_error
+
         # Wait at least 2 seconds with Analog Discovery for the offset to stabilize, before the first reading after
         # device open or offset/range change
         time.sleep(2)
@@ -234,8 +243,8 @@ class AnalogDiscovery2(QMI_Instrument):
     def get_analog_input_sample(self, channel: int) -> float:
         """Readout voltage on specified channel.
 
-        Args:
-            channel: the desired channel to query.
+        Parameters:
+            channel: the target channel to query.
 
         Raises:
             QMI_UsageException: Raised when a device is used before it is opened.
@@ -250,22 +259,22 @@ class AnalogDiscovery2(QMI_Instrument):
             sample = analog_in.statusSample(channel)
         except pydwf.DwfLibraryError as library_error:
             raise QMI_InstrumentException(str(library_error)) from library_error
+
         return sample
 
     @rpc_method
-    def get_analog_input_acquire_samples(self, channel: int, timeout: Optional[float] = None) -> np.ndarray:
+    def get_analog_input_acquire_samples(self, channel: int, timeout: float | None = None) -> np.ndarray:
         """Acquire analog input samples.
 
-        Args:
-            channel: the desired channel to query.
-            timeout: time before timeout exception is raised while waiting on sampling acquisition to finish. This
-                method blocks indefinitely if None is provided and the measurement is not finished.
+        Parameters:
+            channel: The target channel to acquire samples from.
+            timeout: Time before timeout exception is raised while waiting on sampling acquisition to finish. This
+                     method blocks indefinitely if 'None' is provided and the measurement is not finished.
 
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_TimeoutException: QMI_TimeoutException is raised when a timeout occurs while waiting for the sampling
-                acquisition to finish.
-            QMI_InstrumentException: QMI_InstrumentException is raised when an unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_TimeoutException:    Raised when a timeout occurs while waiting for the sampling acquisition to finish.
+            QMI_InstrumentException: Raised when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -286,17 +295,20 @@ class AnalogDiscovery2(QMI_Instrument):
             samples = analog_in.statusData(channel, buffer_size)
         except pydwf.DwfLibraryError as library_error:
             raise QMI_InstrumentException(str(library_error)) from library_error
+
         return samples
 
     @rpc_method
-    def prepare_analog_input_record(self,
-                                    channel: int,
-                                    voltage_range: float,
-                                    record_length: float,
-                                    acquisition_frequency: float,
-                                    voltage_offset: float = 0.0,
-                                    adc_filter: Filter = Filter.AVERAGE) -> None:
-        """Prepare a analog input record for specified channel.
+    def prepare_analog_input_record(
+        self,
+        channel: int,
+        voltage_range: float,
+        record_length: float,
+        acquisition_frequency: float,
+        voltage_offset: float = 0.0,
+        adc_filter: Filter = Filter.AVERAGE
+    ) -> None:
+        """Prepare an analog input record for specified channel.
 
         Raises:
             QMI_UsageException: Raised when a device is used before it is opened.
@@ -316,25 +328,25 @@ class AnalogDiscovery2(QMI_Instrument):
             analog_in.channelFilterSet(channel, pydwf.DwfAnalogInFilter(adc_filter.value))
         except pydwf.DwfLibraryError as library_error:
             raise QMI_InstrumentException(str(library_error)) from library_error
+
         # Wait at least 2 seconds with Analog Discovery for the offset to stabilize, before the first reading after
         # device open or offset/range change
         time.sleep(2)
 
     @rpc_method
-    def get_analog_input_record(self, channel: int, amount_samples: Optional[int] = None) -> typing.List[float]:
-        """Obtain record of input voltages on specified channel.
+    def get_analog_input_record(self, channel: int, amount_samples: int | None = None) -> list[float]:
+        """Obtain a record of input voltages from specified channel.
 
-        Args:
-            channel: the desired channel to query.
+        Parameters:
+            channel:        The target channel to query.
             amount_samples: The amount of samples to take. Only relevant when record length is set to -1.
 
         Returns:
-            Record of input voltages.
+            sample_record:  A record of input voltages.
 
         Raises:
-            QMI_UsageException: Raised when a device is used before it is opened.
-            QMI_InstrumentException: QMI_InstrumentException is raised when data is corrupt or lost or when an
-                unexpected instrument error occurs.
+            QMI_UsageException:      Raised when a device is used before it is opened.
+            QMI_InstrumentException: Raised when data is corrupt or lost or when an unexpected instrument error occurs.
         """
         if self._device is None:
             raise QMI_UsageException("Device should be opened before use.")
@@ -345,14 +357,18 @@ class AnalogDiscovery2(QMI_Instrument):
             if amount_samples is None:
                 amount_samples_rational = analog_in.recordLengthGet() // analog_in.frequencyGet()
                 amount_samples = int(amount_samples_rational)
+
             start_time = time.monotonic()
             analog_in.configure(False, True)
             while len(sample_record) < amount_samples and time.monotonic() < start_time + 0.5:
                 status = analog_in.status(True)
-                if len(sample_record) == 0 and status in (pydwf.DwfState.Config,
-                                                          pydwf.DwfState.Prefill,
-                                                          pydwf.DwfState.Armed):
+                if len(sample_record) == 0 and status in (
+                    pydwf.DwfState.Config,
+                    pydwf.DwfState.Prefill,
+                    pydwf.DwfState.Armed
+                ):
                     continue
+
                 data_available, data_lost, data_corrupt = analog_in.statusRecord()
                 if data_lost > 0 or data_corrupt > 0:
                     raise QMI_InstrumentException('Data was corrupt or lost when obtaining analog input record.')
@@ -360,8 +376,10 @@ class AnalogDiscovery2(QMI_Instrument):
                     continue
                 if data_available + len(sample_record) > amount_samples:
                     data_available = amount_samples - len(sample_record)
+
                 samples = analog_in.statusData(channel, data_available)
                 sample_record = np.append(sample_record, samples)
+
         except pydwf.DwfLibraryError as library_error:
             raise QMI_InstrumentException(str(library_error)) from library_error
 

--- a/qmi/instruments/digilent/analog_discovery.py
+++ b/qmi/instruments/digilent/analog_discovery.py
@@ -352,7 +352,7 @@ class AnalogDiscovery2(QMI_Instrument):
             raise QMI_UsageException("Device should be opened before use.")
 
         analog_in = self._device.analogIn
-        sample_record: np._typing.NDArray[np.float64] = np.array([])
+        sample_record: np.typing.NDArray[np.float64] = np.array([])
         try:
             if amount_samples is None:
                 amount_samples_rational = analog_in.recordLengthGet() // analog_in.frequencyGet()

--- a/qmi/instruments/picotech/_picoscope.py
+++ b/qmi/instruments/picotech/_picoscope.py
@@ -351,7 +351,7 @@ class PicoTech_PicoScope(QMI_Instrument):
         # Convert data to Numpy array.
         samples: np._typing.NDArray[np.int16] = np.empty((len(channels), self._num_samples), dtype=np.int16)
         for (i, chan) in enumerate(channels):
-            samples[i] = buffers[chan]
+            samples[i] = np.ctypeslib.as_array(buffers[chan])
 
         # Extract overrange markers.
         overrange = [bool((par_overflow.value >> chan) & 1) for chan in channels]

--- a/qmi/instruments/picotech/_picoscope.py
+++ b/qmi/instruments/picotech/_picoscope.py
@@ -2,7 +2,8 @@ import importlib
 import logging
 import time
 import enum
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 import ctypes
 
 import numpy as np
@@ -21,7 +22,7 @@ else:
     _ps = None
 
 # Global dictionary for the imported library commands.
-COMMAND_DICT: dict[str, Any] = dict()
+COMMAND_DICT: dict[str, Callable] = dict()
 # Global variable holding the logger for this module.
 _logger = logging.getLogger(__name__)
 
@@ -349,7 +350,7 @@ class PicoTech_PicoScope(QMI_Instrument):
             )
 
         # Convert data to Numpy array.
-        samples: np._typing.NDArray[np.int16] = np.empty((len(channels), self._num_samples), dtype=np.int16)
+        samples: np.typing.NDArray[np.int16] = np.empty((len(channels), self._num_samples), dtype=np.int16)
         for (i, chan) in enumerate(channels):
             samples[i] = np.ctypeslib.as_array(buffers[chan])
 

--- a/qmi/instruments/picotech/_picoscope.py
+++ b/qmi/instruments/picotech/_picoscope.py
@@ -349,7 +349,7 @@ class PicoTech_PicoScope(QMI_Instrument):
             )
 
         # Convert data to Numpy array.
-        samples = np.empty((len(channels), self._num_samples), dtype=np.int16)
+        samples: np._typing.NDArray[np.int16] = np.empty((len(channels), self._num_samples), dtype=np.int16)
         for (i, chan) in enumerate(channels):
             samples[i] = buffers[chan]
 

--- a/qmi/instruments/picotech/picoscope3403.py
+++ b/qmi/instruments/picotech/picoscope3403.py
@@ -8,7 +8,7 @@ https://github.com/picotech/picosdk-python-wrappers.
 
 import ctypes
 import logging
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import warnings
 
 import numpy as np
@@ -42,8 +42,8 @@ class PicoTech_PicoScope3403(PicoTech_PicoScope):
     def __init__(self, context: QMI_Context, name: str, serial_number: str) -> None:
         """Initialize the instrument driver.
 
-        Arguments:
-            name: Name for this instrument instance.
+        Parameters:
+            name:          Name for this instrument instance.
             serial_number: Serial number of the Picoscope.
         """
         super().__init__(context, name, serial_number)
@@ -123,14 +123,14 @@ class PicoTech_PicoScope3403(PicoTech_PicoScope):
     @rpc_method
     def acquire_by_trigger_and_get_data(
         self,
-        channels: List[int],
-        max_val: List[float],
-        couplings: List[ChannelCoupling],
-        trigger_channel: Optional[int],
+        channels: list[int],
+        max_val: list[float],
+        couplings: list[ChannelCoupling],
+        trigger_channel: int | None,
         trigger_level: float,
         sampling_interval: int,
         time_span: int,
-            ) -> object:
+    ) -> object:
         """Acquires data from a specific channel, which is triggered, and returns the data.
 
         It is assumed that the trigger level is set to (almost) the highest point of
@@ -156,8 +156,8 @@ class PicoTech_PicoScope3403(PicoTech_PicoScope):
             time_span:         Time span of data acquiring in nanoseconds.
 
         Returns:
-            (times, voltages): `times` is a 1D Numpy array containing the sampling times in ns.
-                               `voltages` is a 1D Numpy array containing the measured voltages in V.
+            times:    A 1D Numpy array containing the sampling times in ns.
+            voltages: A 1D Numpy array containing the measured voltages in V.
         """
         warnings.warn(
             f"{self.acquire_by_trigger_and_get_data.__name__} will be deprecated in the future as it is not a base "
@@ -249,8 +249,7 @@ class PicoTech_PicoScope3403(PicoTech_PicoScope):
                          The effective time resolution is (timebase-2)/(125000000) for timebase > 2.
 
         Returns:
-            resolution:  Scope's time resolution in nanoseconds.
-                         0 is returned for invalid time_base.
+            resolution:  Scope's time resolution in nanoseconds. 0 is returned for invalid time_base.
         """
         if 0 <= time_base <= 2:
             return 2.0 ** time_base

--- a/qmi/instruments/picotech/picoscope4824.py
+++ b/qmi/instruments/picotech/picoscope4824.py
@@ -8,7 +8,7 @@ https://github.com/picotech/picosdk-python-wrappers .
 
 import ctypes
 import logging
-import typing
+from typing import TYPE_CHECKING
 
 from qmi.core.context import QMI_Context
 from qmi.core.rpc import rpc_method
@@ -16,7 +16,7 @@ from qmi.core.rpc import rpc_method
 from qmi.instruments.picotech._picoscope import PicoTech_PicoScope, _check_error
 
 # Lazy import of the "picosdk" module. See the function _import_modules() in _picoscope.py.
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from picosdk.ps4000a import ps4000a as _ps
 else:
     _ps = None


### PR DESCRIPTION
The `analog_discovery` error was fixed by typing `sample_record: np._typing.NDArray[np.float64]` and returning `list(sample_record)` instead of `sample_record.to_list()` where the latter gives a range of possible typings.

The `_picoscope.py` was fixed by typing `buffers: list[ctypes.Array[ctypes.c_int16]]` and `samples: np._typing.NDArray[np.int16]`, and then converting the `buffers[chan]` ctypes arrays into Numpy arrays with `np.ctypeslib.as_array(buffers[chan])`

