### PR TITLE
[QMI-131] Changing again the README.md badge links. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![pylint](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/pylint.svg)](https://github.com/QuTech-Delft/QMI)
-[![mypy](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/mypy.svg)](https://github.com/QuTech-Delft/QMI)
+[![pylint](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/pylint.svg)](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/pylint.svg)
+[![mypy](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/mypy.svg)](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/mypy.svg)
 [![Documentation Status](https://readthedocs.org/projects/qmi/badge/?version=latest)](https://qmi.readthedocs.io/en/latest/?badge=latest)
-[![coverage](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/coverage.svg)](https://github.com/QuTech-Delft/QMI)
-[![tests](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/tests.svg)](https://github.com/QuTech-Delft/QMI)
+[![coverage](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/coverage.svg)](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/coverage.svg)
+[![tests](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/tests.svg)](https://github.com/QuTech-Delft/QMI/blob/main/.github/badges/tests.svg)
 
 # Quantum Measurement Infrastructure
 

--- a/qmi/core/logging_init.py
+++ b/qmi/core/logging_init.py
@@ -1,6 +1,7 @@
 """Initialization of the Python logging framework for QMI.
 
 Logging framework can be configured using the "logging" and "log_dir" sections of the QMI configuration file, e.g.:
+
 ```json
 {
     # Log level for messages to the console.
@@ -24,7 +25,7 @@ to show DEBUG info on the console, and to write into max three log files (the la
 of 1MB. The location of the log file named 'debug.log' is in 'log_dir' folder of the QMI home directory.  The loglevel
 setting is overridden with module-specific settings, for modules `qmi.core.rpc` and `qmi.core.task`, to be "ERROR".
 
-The default `log levels <https://docs.python.org/3/library/logging.html#logging-levels>` for QMI are "INFO" for the
+The default [`log levels`](https://docs.python.org/3/library/logging.html#logging-levels) for QMI are "INFO" for the
 log file and "WARNING" for the console. The standard log file name is 'qmi.log'.
 """
 import os.path


### PR DESCRIPTION
The latest change did not work well, see https://pypi.org/project/qmi/. The badges at least linked to the correct badge in https://pypi.org/project/qmi/0.47.0/. Try clicking on the badge to see. Now trying with full path links on both sides of the image link. Perhaps this way it gets projected also on the Pypi page.
