### PR TITLE
Add yokogawa dlm4038 qmi driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored also unit-tests for Agiltron FF optical switches.
 
 ### Fixed
+- In `usbtmc.py` now doing `.strip()` on `dev.serial_number` string to avoid SNs with whitespace character(s).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Thorlabs KDC101 controller QMI driver. It can at the moment control Z906, Z912 and Z925 actuators and PRMTZ8 rotation stage.
-- New QMI driver for Agiltron FF1x8 optical switch
+- New QMI driver for Agiltron FF1x8 optical switch.
+- New QMI driver for Yokogawa DLM4038 oscilloscope.
 
 ### Changed
 - The Agiltron FF optical switch QMI drivers have now common base class in `qmi.instruments.agiltron._ff_optical_switch`

--- a/documentation/sphinx/source/tutorial.rst
+++ b/documentation/sphinx/source/tutorial.rst
@@ -852,3 +852,24 @@ and then after it should be stopped::
 
 At the moment no further commands are enabled and any other command exits the server.
 This functionality might get deprecated in the future.
+
+USBTMC devices
+==============
+
+Connecting with USBTMC devices on Windows can be tricky. Make sure you have libusb1 and pyvisa installed.
+https://pypi.org/project/libusb1/ and https://pypi.org/project/PyVISA/ (and perhaps pyvisa-py).
+
+Then you'll need to have the backend set-up correctly, in case the ``libusb-1.0.dll`` is not found in your path.
+An example script to set-up and test the backend is
+```python
+import usb.core
+from usb.backend import libusb1
+
+backend = libusb1.get_backend(
+    find_library=lambda x: "<path_to_your_env>\\Lib\\site-packages\\usb1\\libusb-1.0.dll")
+
+dev = list(usb.core.find(find_all=True))
+```
+
+If you can now find devices, the backend is set correctly. There are of course other ways to set-up your backend
+as well, but as said, it can be tricky...

--- a/qmi/instruments/yokogawa/__init__.py
+++ b/qmi/instruments/yokogawa/__init__.py
@@ -1,0 +1,7 @@
+"""
+Yokogawa, oscilloscopes.
+
+The qmi.instruments.yokogawa package provides support for:
+  - DLM4038 model.
+"""
+from qmi.instruments.yokogawa.dlm4038 import Yokogawa_DLM4038 as Yokogawa_Dlm4038

--- a/qmi/instruments/yokogawa/dlm4038.py
+++ b/qmi/instruments/yokogawa/dlm4038.py
@@ -72,7 +72,11 @@ class Yokogawa_DLM4038(QMI_Instrument):
         return data_type
 
     def _channel_value_setter(
-            self, channels: int | list[int], values: str | list[int | float], parameter: str, unit: str = ""
+            self,
+            channels: int | list[int],
+            values: str | int | float | list[int | float],
+            parameter: str,
+            unit: str = ""
     ) -> None:
         """A helper function to handle logic on setting diverse lengths of various channel parameters."""
         if isinstance(channels, int) and (

--- a/qmi/instruments/yokogawa/dlm4038.py
+++ b/qmi/instruments/yokogawa/dlm4038.py
@@ -55,7 +55,7 @@ class Yokogawa_DLM4038(QMI_Instrument):
 
     def _channels_check(self, channels: int | list[int] | str) -> int | list[int]:
         """Check for string type 'all' and return 'channels' as a list of integers"""
-        if channels.lower() == "all":
+        if isinstance(channels, str) and channels.lower() == "all":
             return list(range(1, self.CHANNELS + 1))
 
         assert not isinstance(channels, str)

--- a/qmi/instruments/yokogawa/dlm4038.py
+++ b/qmi/instruments/yokogawa/dlm4038.py
@@ -351,9 +351,9 @@ class Yokogawa_DLM4038(QMI_Instrument):
         self._scpi_protocol.write(":WAV:FORM BYTE")
         _ = self.get_number_data_points()
         self._scpi_protocol.write(f":FILE:SAVE:NAME {name}")
-        if data_type == "binary":
+        if data_type.lower() == "binary":
             self._scpi_protocol.write(":FILE:SAVE:BINary:EXECute")
-        elif data_type == "ascii":
+        elif data_type.lower() == "ascii":
             self._scpi_protocol.write(":FILE:SAVE:ASCii:EXECute")
         else:
             raise QMI_InstrumentException(f"Unexpected data type, got {data_type}")
@@ -431,9 +431,9 @@ class Yokogawa_DLM4038(QMI_Instrument):
             select_files: Optional parameter to select only the "last" file (default) or "all" the files.
             data_type:    Specify with type: 'binary' for raw data and 'ascii' for csv data file.
         """
-        if data_type == "binary":
+        if data_type.lower() == "binary":
             data_type = "BINary"
-        elif data_type == "ascii":
+        elif data_type.lower() == "ascii":
             data_type = "ASCii"
         else:
             raise QMI_InstrumentException(f"Unexpected data type, got {data_type}")

--- a/qmi/instruments/yokogawa/dlm4038.py
+++ b/qmi/instruments/yokogawa/dlm4038.py
@@ -260,7 +260,7 @@ class Yokogawa_DLM4038(QMI_Instrument):
         if channels == "all":
             channels = list(range(1, self.CHANNELS + 1))
 
-        v_max = self._channel_value_getter(channels, "MAXimum:VALUE", 19, "MEASURE")
+        v_max = self._channel_value_getter(channels, "MAXimum:VALUE", 19, "MEASure")  # TODO: Test with HW
 
         return np.array(v_max, dtype=float)
 
@@ -318,7 +318,7 @@ class Yokogawa_DLM4038(QMI_Instrument):
         """
         Gets the number of data points that will be saved.
         """
-        return int(self._scpi_protocol.ask(":WAVeform:LENGth?")[10:-1])
+        return int(self._scpi_protocol.ask(":WAVeform:LENGth?")[10:-1])  # TODO: range 10:-1 needs to be checked with HW
 
     @rpc_method
     def set_average(self, average: int) -> None:

--- a/qmi/instruments/yokogawa/dlm4038.py
+++ b/qmi/instruments/yokogawa/dlm4038.py
@@ -4,8 +4,11 @@ Instrument driver for the Yokogawa DLM4038 Oscilloscope. The instrument can be c
 If the instrument is connected over ethernet, use the vxi11 protocol by passing the transport description
 "vxi11:ip-address". If the mass storage function (over USB) is used, the scope directory needs to be specific
 (default is "O:/").
-Connecting to the instrument through USB is also possible but has not been tested. In that case, the transport
-description is likely to be either "usbtmc:<vendorid>:<productid>:<serialnr>" or with a GPIB adapter "gbip:<address>".
+
+Connecting to the instrument through USB is also possible but could not be tested. The testing was done on a
+Windows 11 PC but the installation of the device driver to recognize the instrument correctly through USB was
+not successful. In principle, the transport descriptor is likely to be either
+"usbtmc:vendorid=0x0b21:productid=0x0038:serialnr=<serialnr>", or with a GPIB adapter "gbip:<address>".
 """
 
 import logging
@@ -151,7 +154,9 @@ class Yokogawa_DLM4038(QMI_Instrument):
         Parameters:
             state: True to set High Resolution mode on, False to set it off.
         """
-        self._scpi_protocol.write(":ACQUIRE:RESOLUTION " + str(state))
+        # self._scpi_protocol.write(":ACQUIRE:RESOLUTION " + str(state))
+        state_str = "ON" if state else "OFF"
+        self._scpi_protocol.write(":ACQUIRE:RESOLUTION " + state_str)
 
     @rpc_method
     def turn_channel_on(self, channels: int | list[int] | str) -> None:
@@ -293,7 +298,7 @@ class Yokogawa_DLM4038(QMI_Instrument):
         Parameters:
             channel: The trigger channel number.
         """
-        self._scpi_protocol.ask(f":TRIGger:ATRigger:SIMPle:SOURce {channel}")
+        self._scpi_protocol.write(f":TRIGger:ATRigger:SIMPle:SOURce {channel}")
 
     @rpc_method
     def set_trigger_level(self, voltage: float) -> None:
@@ -318,7 +323,7 @@ class Yokogawa_DLM4038(QMI_Instrument):
         """
         Gets the number of data points that will be saved.
         """
-        return int(self._scpi_protocol.ask(":WAVeform:LENGth?")[10:-1])  # TODO: range 10:-1 needs to be checked with HW
+        return int(self._scpi_protocol.ask(":WAVeform:LENGth?")[10:])  # TODO: range 10:-1 needs to be checked with HW
 
     @rpc_method
     def set_average(self, average: int) -> None:

--- a/qmi/instruments/yokogawa/dlm4038_new.py
+++ b/qmi/instruments/yokogawa/dlm4038_new.py
@@ -1,0 +1,449 @@
+"""
+Instrument driver for the Yokogawa DLM4038 Oscilloscope. The instrument can be connected over ethernet and usb.
+
+If the instrument is connected over ethernet, use the vxi11 protocol by passing the transport description
+"vxi11:ip-address". If the mass storage function (over USB) is used, the scope directory needs to be specific
+(default is "O:/").
+Connecting to the instrument through USB is also possible but has not been tested. In that case, the transport
+description is likely to be either "usbtmc:<vendorid>:<productid>:<serialnr>" or with a GPIB adapter "gbip:<address>".
+"""
+
+import logging
+import os
+import shutil
+import time
+
+import numpy as np
+from qmi.core.context import QMI_Context
+from qmi.core.exceptions import QMI_InstrumentException, QMI_UsageException
+from qmi.core.instrument import QMI_Instrument, QMI_InstrumentIdentification
+from qmi.core.rpc import rpc_method
+from qmi.core.scpi_protocol import ScpiProtocol
+from qmi.core.transport import create_transport
+
+# Global variable holding the logger for this module.
+_logger = logging.getLogger(__name__)
+
+
+class Yokogawa_DLM4038(QMI_Instrument):
+    """Instrument driver for the Yokogawa DLM4038 Oscilloscope.
+    
+    Arguments:
+        CHANNELS: The number of signal channels in the device.
+    """
+    _rpc_constants = ["CHANNELS"]
+    CHANNELS = 8
+
+    def __init__(
+            self, context: QMI_Context, name: str, transport: str, directory: str | None = "O:/", timeout: float = 1.0
+    ) -> None:
+        """Initialize the instrument driver.
+
+        Parameters:
+            name:      Name for this instrument instance.
+            transport: QMI transport descriptor to connect to the instrument.
+            directory: Path to the scope mass storage. Default is "O:/".
+            timeout:   Scope response timeout. Default is 1.0.
+        """
+        super().__init__(context, name)
+        self._transport = create_transport(transport)
+        self._scpi_protocol = ScpiProtocol(self._transport, default_timeout=timeout)
+        self._directory_oscilloscope = directory
+
+    def _channel_value_setter(
+            self, channels: int | list[int], values: str | list[int | float], parameter: str, unit: str = ""
+    ) -> None:
+        """A helper function to handle logic on setting diverse lengths of various channel parameters."""
+        if isinstance(channels, int) and (
+                isinstance(values, float) or isinstance(values, int) or isinstance(values, str)
+        ):  # Single channel setter
+            self._scpi_protocol.write(f":CHANnel{channels}:{parameter} {values}{unit}")
+
+        elif not isinstance(values, list) and isinstance(channels, list):
+            # Set the same value for all channels
+            for chan in channels:
+                self._scpi_protocol.write(f":CHANnel{chan}:{parameter} {values}{unit}")
+
+        elif isinstance(values, list) and isinstance(channels, list):
+            # Multi-channel setter with values per channel
+            if len(values) != len(channels):
+                raise QMI_UsageException(f"Invalid number of values ({len(values)}) for {len(channels)} channels.")
+
+            for chan, val in zip(channels, values):
+                self._scpi_protocol.write(f":CHANnel{chan}:{parameter} {val}{unit}")
+
+        else:
+            _logger.error("%s {parameter} not set due to invalid parameters: %d, %d", self._name, channels, values)
+
+    def _channel_value_getter(
+            self, channels: int | list[int], parameter: str, val_start: int, preposition: str = ""
+    ) -> list[str]:
+        """A helper function for getting various channel parameter values."""
+        if len(preposition) > 0 and not preposition.startswith(":"):
+            preposition = ":" + preposition
+
+        values = []
+        if isinstance(channels, int):
+            channels = [channels]
+
+        for chan in channels:
+            current_value = self._scpi_protocol.ask(f"{preposition}:CHANnel{chan}:{parameter}?")
+            values.append(current_value[val_start:])
+
+        return values
+
+    @rpc_method
+    def open(self) -> None:
+        _logger.info("[%s] Opening connection to instrument", self._name)
+        self._check_is_closed()
+        self._transport.open()
+        super().open()
+
+    @rpc_method
+    def close(self) -> None:
+        _logger.info("[%s] Closing connection to instrument", self._name)
+        super().close()
+        self._transport.close()
+
+    @rpc_method
+    def get_idn(self) -> QMI_InstrumentIdentification:
+        """Read instrument type and version and return QMI_InstrumentIdentification instance."""
+        resp = self._scpi_protocol.ask("*IDN?")
+        words = resp.rstrip().split(",")
+        if len(words) != 4:
+            raise QMI_InstrumentException(f"Unexpected response to *IDN?, got {resp!r}")
+        return QMI_InstrumentIdentification(
+            vendor=words[0].strip(), model=words[1].strip(), serial=words[2].strip(), version=words[3].strip()
+        )
+
+    @rpc_method
+    def start(self) -> None:
+        """Start waveform acquisition."""
+        self._scpi_protocol.write(":START")
+
+    @rpc_method
+    def stop(self) -> None:
+        """Stop waveform acquisition."""
+        self._scpi_protocol.write(":STOP")
+
+    @rpc_method
+    def set_time_division(self, time_division: float) -> None:
+        """Set the Time/div value.
+
+        Parameters:
+            time_division: The new Time/div value in seconds.
+        """
+        self._scpi_protocol.write(f":TIMEBASE:TDIV {time_division}")
+
+    @rpc_method
+    def get_time_division(self) -> float:
+        """Get the Time/div value.
+
+        Returns:
+            time_division: The current Time/div value in seconds.
+        """
+        return float(self._scpi_protocol.ask(":TIMEBASE:TDIV?")[9:])
+
+    @rpc_method
+    def set_high_resolution(self, state: bool) -> None:
+        """Set the High Resolution mode on or off.
+
+        Parameters:
+            state: True to set High Resolution mode on, False to set it off.
+        """
+        self._scpi_protocol.write(":ACQUIRE:RESOLUTION " + str(state))
+
+    @rpc_method
+    def turn_channel_on(self, channels: int | list[int] | str) -> None:
+        """Turns on the display of specified channel or channels.
+        
+        Parameters:
+            channels: A single channel number or a list of selected channels. Use "all" for all channels.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        self._channel_value_setter(channels, "ON", "DISPlay")
+
+    @rpc_method
+    def turn_channel_off(self, channels: int | list[int] | str) -> None:
+        """Turns off the display of specified channel or channels.
+
+        Parameters:
+            channels: A single channel number or a list of selected channels. Use "all" for all channels.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        self._channel_value_setter(channels, "OFF", "DISPlay")
+
+    @rpc_method
+    def set_voltage_offset(self, channels: int | list[int] | str, v_offset: float | list[float]) -> None:
+        """Sets the voltage offset for the specified channels. Voltage offset is specified in volts.
+
+        Parameters:
+            channels: A single channel number or a list of selected channels. Use "all" for all channels.
+            v_offset: A single voltage or a list of voltages. Can be given as one value which is then applied to
+                      all 'channels'. Otherwise, length must match with 'channels'.
+
+        Raises:
+            QMI_UsageException: If the given input channels and v_offset parameters do not match.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        self._channel_value_setter(channels, v_offset, "OFFset", "V")
+
+    @rpc_method
+    def get_voltage_offset(self, channels: int | list[int] | str) -> np.ndarray:
+        """Returns the current voltage offset for the specified channels.
+
+        Parameters:
+            channels: A single channel number or a list of selected channels. Use "all" for all channels.
+
+        Returns:
+            v_offset: An array of offset values, respective to the size of given input channels.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        v_offset = self._channel_value_getter(channels, "OFFset", 11)
+
+        return np.array(v_offset, dtype=float)
+
+    @rpc_method
+    def set_voltage_division(self, channels: int | list[int] | str, v_division: float | list[float]) -> None:
+        """Set the voltage division for the specified channels. Voltage division is specified in Volts.
+
+        Parameters:
+            channels:   A single channel number or a list of selected channels. Use "all" for all channels.
+            v_division: A single voltage or a list of voltages. Can be given as one value which is then applied to
+                        all 'channels'. Otherwise, length must match with 'channels'.
+
+        Raises:
+            QMI_UsageException: If the given input channels and v_division parameters do not match.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        self._channel_value_setter(channels, v_division, "VDIV", "V")
+
+    @rpc_method
+    def get_voltage_division(self, channels: int | list[int] | str) -> np.ndarray:
+        """Returns the current voltage per division for the specified channels.
+
+        Parameters:
+            channels:   A single channel number or a list of selected channels. Use "all" for all channels.
+
+        Returns:
+            v_division: An array of division values, respective to the size of given input channels.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        v_division = self._channel_value_getter(channels, "VDIV", 12)
+
+        return np.array(v_division, dtype=float)
+
+    @rpc_method
+    def get_max_waveform(self, channels: int | list[int] | str) -> np.ndarray:
+        """Returns the current waveform maximum for the specified channels.
+
+        WARNING: Undocumented feature.
+
+        Parameters:
+            channels: A single channel number or a list of selected channels. Use "all" for all channels.
+
+        Returns:
+            v_max: An array of waveform maximum voltage values, respective to the size of given input channels.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        v_max = self._channel_value_getter(channels, "MAXimum:VALUE", 19, "MEASURE")
+
+        return np.array(v_max, dtype=float)
+
+    @rpc_method
+    def set_channel_position(self, channels: int | list[int] | str, position: float | list[float]) -> None:
+        """
+        Changes the position of the specified channels in volts.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        self._channel_value_setter(channels, position, "POSition")
+
+    @rpc_method
+    def get_channel_position(self, channels: int | list[int] | str) -> np.ndarray:
+        """
+        Returns the current position for the specified channels in volts.
+        """
+        if channels == "all":
+            channels = list(range(1, self.CHANNELS + 1))
+
+        position = self._channel_value_getter(channels, "POSition", 11)
+
+        return np.array(position, dtype=float)
+
+    @rpc_method
+    def set_trigger_channel(self, channel: int) -> None:
+        """Sets the channel used to set the trigger.
+
+        Parameters:
+            channel: The trigger channel number.
+        """
+        self._scpi_protocol.ask(f":TRIGger:ATRigger:SIMPle:SOURce {channel}")
+
+    @rpc_method
+    def set_trigger_level(self, voltage: float) -> None:
+        """Sets the level (in volts) of the trigger.
+
+        Parameters:
+            voltage: The trigger voltage level.
+        """
+        self._scpi_protocol.write(f":TRIGger:ATRigger:SIMPle:LEVel {voltage}V")
+
+    @rpc_method
+    def set_number_data_points(self, length: int) -> None:
+        """Sets the scope acquire length.
+
+        Parameters:
+            length: The acquire length value.
+        """
+        self._scpi_protocol.write(f":ACQuire:RLENgth {length}")
+
+    @rpc_method
+    def get_number_data_points(self) -> int:
+        """
+        Gets the number of data points that will be saved.
+        """
+        return int(self._scpi_protocol.ask(":WAVeform:LENGth?")[10:-1])
+
+    @rpc_method
+    def set_average(self, average: int) -> None:
+        """Sets the mode to average and set the average count.
+
+         Parameters:
+             average: Has to be between 2 and 1024 in 2**n steps.
+        """
+        self._scpi_protocol.write(":ACQUIRE:MODE AVERAGE")
+        self._scpi_protocol.write(f":ACQUIRE:AVERAGE:COUNT {average}")
+
+    @rpc_method
+    def set_normal(self) -> None:
+        """Sets acquisition mode to normal."""
+        self._scpi_protocol.write(":ACQUIRE:MODE NORMAL")
+
+    @rpc_method
+    def save_file(self, name: str, data_type: str = "binary", waiting_time: float = 12.0) -> None:
+        """Saves in the internal memory the file with a name "nameXXX.csv".
+        Here XXX labels the files that have the same name with numbers from 000 to 999.
+
+        Parameters:
+            name:         The preposition of the file name.
+            data_type:    Specify with type: 'binary' for raw data and 'ascii' for csv data.
+            waiting_time: Time to wait for saving the file. In seconds.
+        """
+        # Stops in order to acquire the data
+        self._scpi_protocol.write(":STOP")
+        # Parameters of the saved file
+        self._scpi_protocol.write(":WAV:FORM BYTE")
+        _ = self.get_number_data_points()
+        self._scpi_protocol.write(f":FILE:SAVE:NAME {name}")
+        if data_type == "binary":
+            self._scpi_protocol.write(":FILE:SAVE:BINary:EXECute")
+        elif data_type == "ascii":
+            self._scpi_protocol.write(":FILE:SAVE:ASCii:EXECute")
+        else:
+            raise QMI_InstrumentException(f"Unexpected data type, got {data_type}")
+
+        # waits until the save is completed
+        time.sleep(waiting_time)
+        # Starts again, notice that at least a time of 10*time_division is needed to get a full spectrum after starting
+        self._scpi_protocol.write(":START")
+
+    @rpc_method
+    def find_file_name(self, name: str, select_files: str = "last") -> str | list[str]:
+        """Finds the files in the oscilloscope with names 'nameXXX.csv'.
+        It can be chosen whether to return the last file created with that name (higher XXX) with select_files = 'last'
+        or to return all of them with select_files = 'all'.
+
+        The full name including the label numbers can be specified to find a specific file.
+
+        Parameters:
+            name:         Preposition of file names to find.
+            select_files: Optional parameter to select only the "last" file (default) or "all" the files.
+        """
+        # Get all files from the oscilloscope
+        list_files = os.listdir(self._directory_oscilloscope)
+        name = name.upper()
+        if select_files == "last":
+            # Start routine to get the last file with the introduced name
+            for i in range(len(list_files)):
+                # Go through the list in inverse order to find the last file created first
+                file_name = list_files[-i - 1]
+                if file_name.find(name) >= 0:
+                    if len(file_name) == len(name) + 7:
+                        return file_name
+
+        elif select_files == "all":
+            # Start routine to get all files with the same name
+            file_names: list[str] = []
+            for i in range(len(list_files)):
+                file_name = list_files[i]
+                if file_name.find(name) >= 0:
+                    file_names.append(file_name)
+
+            return file_names
+
+        raise QMI_InstrumentException(f"Could not find any files starting with '{name}'")
+
+    @rpc_method
+    def copy_file(self, name: str, destination: str, select_files: str = "last") -> None:
+        """
+        Copies the files in the oscilloscope with names 'nameXXX.csv' to the destination.
+        It can be chosen whether to copy the last file created with that name (higher XXX) with select_files = 'last'
+        or to copy all of them with select_files = 'all'
+        The full name including the label numbers can be specified to copy a specific file.
+
+        Parameters:
+            name:         Preposition of file names to find.
+            destination:  Target directory to copy the file or files to.
+            select_files: Optional parameter to select only the "last" file (default) or "all" the files.
+
+        """
+        file_names: str | list[str] = self.find_file_name(name, select_files)
+        if select_files == "last":
+            file_names = [file_names]
+
+        for f in file_names:
+            shutil.copy(f"{self._directory_oscilloscope}{f}", destination)
+
+    @rpc_method
+    def delete_file(self, name: str, select_files: str = "last", data_type: str = "binary") -> None:
+        """Deletes files in the oscilloscope with names 'nameXXX.csv'.
+        It can be chosen whether to delete the last file created with that name (higher XXX) with select_files = 'last'
+        or to delete all of them with select_files = 'all'.
+
+        Parameters:
+            name:         Preposition of file names to find.
+            select_files: Optional parameter to select only the "last" file (default) or "all" the files.
+            data_type:    Specify with type: 'binary' for raw data and 'ascii' for csv data file.
+        """
+        if data_type == "binary":
+            data_type = "BINary"
+        elif data_type == "ascii":
+            data_type = "ASCii"
+        else:
+            raise QMI_InstrumentException(f"Unexpected data type, got {data_type}")
+
+        self.stop()
+        file_names: str | list[str] = self.find_file_name(name, select_files)
+        if select_files == "last":
+            file_names = [file_names]
+
+        for f in file_names:
+            self._scpi_protocol.write(f':FILE:DELete:{data_type}:EXECute "{f[:-4]}"')
+
+        self.start()

--- a/tests/instruments/yokogawa/test_dlm4308.py
+++ b/tests/instruments/yokogawa/test_dlm4308.py
@@ -1,0 +1,783 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from qmi.core.exceptions import QMI_InstrumentException
+from qmi.core.transport import QMI_Vxi11Transport
+from qmi.core.instrument import QMI_InstrumentIdentification
+from qmi.instruments.yokogawa import Yokogawa_Dlm4038
+
+from tests.patcher import PatcherQmiContext as QMI_Context
+
+
+class TestInstrumentInitCase(unittest.TestCase):
+
+    @patch("qmi.core.transport.vxi11")
+    def test_open_close(self, vxi11_patch):
+        """Test that the class initializes and open and close functions work as expected."""
+        # Arrange
+        expected_path = "O:/"
+        yokogawa = Yokogawa_Dlm4038(QMI_Context("yoko"), "gawa", "vxi11:123.45.67.89")
+        # Act
+        yokogawa.open()
+        # Assert
+        self.assertTrue(yokogawa.is_open())
+        yokogawa.close()
+        self.assertFalse(yokogawa.is_open())
+        self.assertEqual(expected_path, yokogawa._directory_oscilloscope)
+
+    @patch("qmi.core.transport.vxi11")
+    def test_open_close_with_custom_path(self, vxi11_patch):
+        """Test that the initialization with custom path gives the expected path."""
+        # Arrange
+        expected_path = "P:/other_path/than_default"
+        # Act
+        yokogawa = Yokogawa_Dlm4038(QMI_Context("yoko"), "gawa", "vxi11:123.45.67.89", expected_path)
+        # Assert
+        self.assertEqual(expected_path, yokogawa._directory_oscilloscope)
+
+    def test_open_close_calls(self):
+        """Test that the open and close functions include calls as expected."""
+        # Arrange
+        self._transport_mock = MagicMock(spec=QMI_Vxi11Transport)
+        with patch(
+                'qmi.instruments.yokogawa.dlm4038.create_transport',
+                return_value=self._transport_mock):
+
+            # Act
+            self.yokogawa = Yokogawa_Dlm4038(QMI_Context("yoko"), "gawa", "vxi11:123.45.67.89")
+            self.yokogawa.open()
+            # Assert
+            self._transport_mock.open.assert_called_once_with()
+            self._transport_mock.open.reset_mock()
+            self._transport_mock.write.reset_mock()
+            self.yokogawa.close()
+            self._transport_mock.close.assert_called_once_with()
+
+
+class TestMethodsCase(unittest.TestCase):
+
+    def setUp(self):
+        self._transport_mock = MagicMock(spec=QMI_Vxi11Transport)
+        self.def_path = "O:/"
+        with patch(
+                'qmi.instruments.yokogawa.dlm4038.create_transport',
+                return_value=self._transport_mock):
+            self.yokogawa = Yokogawa_Dlm4038(QMI_Context("yoko"), "gawa", "vxi11:123.45.67.89")
+            self.yokogawa.open()
+
+    def tearDown(self):
+        self.yokogawa.close()
+
+    def test_get_idn(self):
+        """Test get_idn function."""
+        # Arrange
+        expected_write = b"*IDN?\n"
+        expected_vendor = "Yokogawa"
+        expected_model = "dlm4308"
+        expected_serial = "S123456"
+        expected_version = "1.23.4"
+        expected_idn = QMI_InstrumentIdentification(
+            expected_vendor, expected_model, expected_serial, expected_version
+        )
+        side_effect = ",".join([expected_vendor, expected_model, expected_serial, expected_version + "\n"])
+        self._transport_mock.read_until.side_effect = [side_effect.encode()]
+        # Act
+        idn = self.yokogawa.get_idn()
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+        self.assertEqual(expected_idn, idn)
+
+    def test_get_idn_exception(self):
+        """Test get_idn function excepts when too few or too many words are returned."""
+        # Arrange
+        expected_response = "Unexpected response to *IDN?, got {resp!r}"
+        expected_write = b"*IDN?\n"
+        side_effect = ["too,few,words\n".encode(), "too,many,words,than,expected\n".encode()]
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        with self.assertRaises(QMI_InstrumentException) as exc:
+            self.yokogawa.get_idn()
+            # Assert
+            self._transport_mock.write.assert_called_once_with(expected_write)
+            self.assertEqual(expected_response.format(side_effect[0].decode()), str(exc.exception))
+
+        # Act
+        with self.assertRaises(QMI_InstrumentException) as exc:
+            self.yokogawa.get_idn()
+            # Assert
+            self._transport_mock.write.assert_called_once_with(expected_write)
+            self.assertEqual(expected_response.format(side_effect[1].decode()), str(exc.exception))
+
+    def test_start(self):
+        """Test start fun."""
+        # Arrange
+        expected_write = b":START\n"
+        # Act
+        self.yokogawa.start()
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_stop(self):
+        """Test stop fun."""
+        # Arrange
+        expected_write = b":STOP\n"
+        # Act
+        self.yokogawa.stop()
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_set_time_division(self):
+        """Test set_time_division method."""
+        # Arrange
+        time_div = 1E6
+        expected_write = f":TIMEBASE:TDIV {time_div:.1f}\n".encode()
+        # Act
+        self.yokogawa.set_time_division(time_div)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_get_time_division(self):
+        """Test get_time_division method."""
+        # Arrange
+        expected_time_div = 1E6
+        expected_write = b":TIMEBASE:TDIV?\n"
+        return_value = b"TIME:TDIV" + f"{expected_time_div:.1f}\n".encode()
+        self._transport_mock.read_until.return_value = return_value
+        # Act
+        time_div = self.yokogawa.get_time_division()
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+        self.assertEqual(expected_time_div, time_div)
+
+    def test_set_high_resolution_on(self):
+        """Test set_high_resolution method with "on"."""
+        # Arrange
+        high_res = True
+        expected_write = f":ACQUIRE:RESOLUTION {high_res}\n".encode()
+        # Act
+        self.yokogawa.set_high_resolution(high_res)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_turn_channel_on(self):
+        """Test turn_channel_on method with one channel."""
+        # Arrange
+        channel = 1
+        state = "ON"
+        expected_write = f":CHANnel{channel}:DISPlay {state}\n".encode()
+        # Act
+        self.yokogawa.turn_channel_on(channel)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_turn_channels_on_some(self):
+        """Test turn_channel_on method with some channel."""
+        # Arrange
+        channels = [1, 3, 5, 7]
+        state = "ON"
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:DISPlay {state}\n".encode()))
+
+        # Act
+        self.yokogawa.turn_channel_on(channels)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_turn_channels_on_all(self):
+        """Test turn_channel_on method with all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        state = "ON"
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:DISPlay {state}\n".encode()))
+
+        # Act
+        self.yokogawa.turn_channel_on("all")
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_turn_channel_off(self):
+        """Test turn_channel_off method with one channel."""
+        # Arrange
+        channel = 1
+        state = "OFF"
+        expected_write = f":CHANnel{channel}:DISPlay {state}\n".encode()
+        # Act
+        self.yokogawa.turn_channel_off(channel)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_turn_channels_off_some(self):
+        """Test turn_channel_off method with some channel."""
+        # Arrange
+        channels = [1, 3, 5, 7]
+        state = "OFF"
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:DISPlay {state}\n".encode()))
+
+        # Act
+        self.yokogawa.turn_channel_off(channels)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_turn_channels_off_all(self):
+        """Test turn_channel_off method with all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        state = "OFF"
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:DISPlay {state}\n".encode()))
+
+        # Act
+        self.yokogawa.turn_channel_off("all")
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_set_voltage_offset(self):
+        """Test set_voltage_offset method on one channel."""
+        # Arrange
+        channel = 2
+        offset = 16.0
+        expected_write = f":CHANnel{channel}:OFFset {offset:.1f}V\n".encode()
+        # Act
+        self.yokogawa.set_voltage_offset(channel, offset)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_set_voltage_offset_some(self):
+        """Test set_voltage_offset method on multiple channels."""
+        # Arrange
+        channels = [2, 4, 6, 8]
+        offset = 16.0
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:OFFset {offset:.1f}V\n".encode()))
+
+        # Act
+        self.yokogawa.set_voltage_offset(channels, offset)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_set_voltage_offset_all(self):
+        """Test set_voltage_offset method on all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        offset = 16.0
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:OFFset {offset:.1f}V\n".encode()))
+
+        # Act
+        self.yokogawa.set_voltage_offset("all", offset)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_get_voltage_offset(self):
+        """Test get_voltage_offset method for one channel."""
+        # Arrange
+        channel = 3
+        expected_offset = 16.0
+        expected_write = f":CHANnel{channel}:OFFset?\n".encode()
+        return_value = b"CHANnel:OFF" + f"{expected_offset:.1f}\n".encode()
+        self._transport_mock.read_until.return_value = return_value
+        # Act
+        offset = self.yokogawa.get_voltage_offset(channel)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+        self.assertEqual(expected_offset, offset)
+
+    def test_get_voltage_offset_some(self):
+        """Test get_voltage_offset method for multiple channels."""
+        # Arrange
+        channels = [1, 3, 5, 7]
+        expected_offset = 16.0
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:OFFset?\n".encode()))
+            side_effect.append(b"CHANnel:OFF" + f"{expected_offset:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        offsets = self.yokogawa.get_voltage_offset(channels)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(expected_offset, offsets[o])
+
+    def test_get_voltage_offset_all(self):
+        """Test get_voltage_offset method for all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        expected_offset = 16.0
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:OFFset?\n".encode()))
+            side_effect.append(b"CHANnel:OFF" + f"{expected_offset:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        offsets = self.yokogawa.get_voltage_offset("all")
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(expected_offset, offsets[o])
+
+    def test_set_voltage_division(self):
+        """Test set_voltage_division method on one channel."""
+        # Arrange
+        channel = 2
+        division = 16.0
+        expected_write = f":CHANnel{channel}:VDIV {division:.1f}V\n".encode()
+        # Act
+        self.yokogawa.set_voltage_division(channel, division)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_set_voltage_division_some(self):
+        """Test set_voltage_division method on multiple channels."""
+        # Arrange
+        channels = [2, 4, 6, 8]
+        division = 16.0
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:VDIV {division:.1f}V\n".encode()))
+
+        # Act
+        self.yokogawa.set_voltage_division(channels, division)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_set_voltage_division_all(self):
+        """Test set_voltage_division method on all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        division = 16.0
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:VDIV {division:.1f}V\n".encode()))
+
+        # Act
+        self.yokogawa.set_voltage_division("all", division)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_get_voltage_division(self):
+        """Test get_voltage_division method for one channel."""
+        # Arrange
+        channel = 4
+        expected_division = 1.6
+        expected_write = f":CHANnel{channel}:VDIV?\n".encode()
+        return_value = b"CHANnel:VDIV" + f"{expected_division:.1f}\n".encode()
+        self._transport_mock.read_until.return_value = return_value
+        # Act
+        division = self.yokogawa.get_voltage_division(channel)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+        self.assertEqual(expected_division, division)
+
+    def test_get_voltage_division_some(self):
+        """Test get_voltage_division method for multiple channels."""
+        # Arrange
+        channels = [2, 4, 6, 8]
+        expected_division = 1.6
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:VDIV?\n".encode()))
+            side_effect.append(b"CHANnel:VDIV" + f"{expected_division:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        divisions = self.yokogawa.get_voltage_division(channels)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(expected_division, divisions[o])
+
+    def test_get_voltage_division_all(self):
+        """Test get_voltage_division method for all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        expected_division = 1.6
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:VDIV?\n".encode()))
+            side_effect.append(b"CHANnel:VDIV" + f"{expected_division:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        divisions = self.yokogawa.get_voltage_division("all")
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(expected_division, divisions[o])
+
+    def test_get_max_waveform(self):
+        """Test get_max_waveform method for one channel."""
+        # Arrange
+        channel = 5
+        expected_max_waveform = 0.16
+        expected_write = f":MEASure:CHANnel{channel}:MAXimum:VALUE?\n".encode()
+        return_value = b"CHANnel:MAXimum:VAL" + f"{expected_max_waveform:.1f}\n".encode()
+        self._transport_mock.read_until.return_value = return_value
+        # Act
+        max_waveform = self.yokogawa.get_max_waveform(channel)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+        self.assertEqual(round(expected_max_waveform, 1), max_waveform)
+
+    def test_get_max_waveform_some(self):
+        """Test get_max_waveform method for multiple channels."""
+        # Arrange
+        channels = [1, 3, 5, 7]
+        expected_max_waveform = 0.16
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":MEASure:CHANnel{channel}:MAXimum:VALUE?\n".encode()))
+            side_effect.append(b"CHANnel:MAXimum:VAL" + f"{expected_max_waveform:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        max_waveforms = self.yokogawa.get_max_waveform(channels)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(round(expected_max_waveform, 1), max_waveforms[o])
+
+    def test_get_max_waveform_all(self):
+        """Test get_max_waveform method for all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        expected_max_waveform = 0.16
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":MEASure:CHANNEL{channel}:MAXimum:VALUE?\n".encode()))
+            side_effect.append(b"CHANnel:MAXimum:VAL" + f"{expected_max_waveform:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        max_waveforms = self.yokogawa.get_max_waveform("all")
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(round(expected_max_waveform, 1), max_waveforms[o])
+
+    def test_set_channel_position(self):
+        """Test set_channel_position method on one channel."""
+        # Arrange
+        channel = 2
+        offset = 16.0
+        expected_write = f":CHANnel{channel}:POSition {offset:.1f}\n".encode()
+        # Act
+        self.yokogawa.set_channel_position(channel, offset)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_set_channel_position_some(self):
+        """Test set_channel_position method on multiple channels."""
+        # Arrange
+        channels = [2, 4, 6, 8]
+        offset = 16.0
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:POSition {offset:.1f}\n".encode()))
+
+        # Act
+        self.yokogawa.set_channel_position(channels, offset)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_set_channel_position_all(self):
+        """Test set_channel_position method on all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        offset = 16.0
+        expected_writes = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:POSition {offset:.1f}\n".encode()))
+
+        # Act
+        self.yokogawa.set_channel_position("all", offset)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_get_channel_position(self):
+        """Test get_channel_position method for one channel."""
+        # Arrange
+        channel = 3
+        expected_offset = 16.0
+        expected_write = f":CHANnel{channel}:POSition?\n".encode()
+        return_value = b"CHANnel:POS" + f"{expected_offset:.1f}\n".encode()
+        self._transport_mock.read_until.return_value = return_value
+        # Act
+        offset = self.yokogawa.get_channel_position(channel)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+        self.assertEqual(expected_offset, offset)
+
+    def test_get_channel_position_some(self):
+        """Test get_channel_position method for multiple channels."""
+        # Arrange
+        channels = [1, 3, 5, 7]
+        expected_offset = 16.0
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:POSition?\n".encode()))
+            side_effect.append(b"CHANnel:POS" + f"{expected_offset:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        offsets = self.yokogawa.get_channel_position(channels)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(expected_offset, offsets[o])
+
+    def test_get_channel_position_all(self):
+        """Test get_channel_position method for all channels."""
+        # Arrange
+        channels = list(range(1, 9))
+        expected_offset = 16.0
+        expected_writes = []
+        side_effect = []
+        for channel in channels:
+            expected_writes.append(unittest.mock.call(f":CHANnel{channel}:POSition?\n".encode()))
+            side_effect.append(b"CHANnel:POS" + f"{expected_offset:.1f}\n".encode())
+
+        self._transport_mock.read_until.side_effect = side_effect
+        # Act
+        offsets = self.yokogawa.get_channel_position("all")
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+        for o in range(len(channels)):
+            self.assertEqual(expected_offset, offsets[o])
+
+    def test_set_trigger_channel(self):
+        """Test set_trigger_channel method."""
+        # Arrange
+        trigger_channel = 5
+        expected_write = f":TRIGger:ATRigger:SIMPle:SOURce {trigger_channel}\n".encode()
+        # Act
+        self.yokogawa.set_trigger_channel(trigger_channel)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_set_trigger_level(self):
+        """Test set_trigger_level method."""
+        # Arrange
+        trigger_level = 5.0
+        expected_write = f":TRIGger:ATRigger:SIMPle:LEVel {trigger_level:.1f}V\n".encode()
+        # Act
+        self.yokogawa.set_trigger_level(trigger_level)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_set_number_data_points(self):
+        """Test set_number_data_points method."""
+        # Arrange
+        ndp = 10500
+        expected_write = f":ACQuire:RLENgth {ndp}\n".encode()
+        # Act
+        self.yokogawa.set_number_data_points(ndp)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_get_number_data_points(self):
+        """Test get_number_data_points method."""
+        # Arrange
+        expected_ndp = int(1.5E6)
+        expected_write = b":WAVeform:LENGth?\n"
+        return_value = b"WAVeform:LENG" + f"{expected_ndp}\n".encode()
+        self._transport_mock.read_until.return_value = return_value
+        # Act
+        ndp = self.yokogawa.get_number_data_points()
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+        self.assertEqual(expected_ndp, ndp)
+
+    def test_set_average(self):
+        """Test set_average method that first sets the mode to average, and then the average value."""
+        # Arrange
+        average = 2**5
+        expected_write = [
+            unittest.mock.call(f":ACQUIRE:MODE AVERAGE\n".encode()),
+            unittest.mock.call(f":ACQUIRE:AVERAGE:COUNT {average}\n".encode())
+        ]
+        # Act
+        self.yokogawa.set_average(average)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_write)
+
+    def test_set_normal(self):
+        """Test set_normal method."""
+        # Arrange
+        expected_write = f":ACQUIRE:MODE NORMAL\n".encode()
+        # Act
+        self.yokogawa.set_normal()
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_save_file(self):
+        """Test save_file method using default binary 'type'."""
+        # Arrange
+        name = "no"
+        expected_type = "BINary"
+        waiting_time = 0.001  # shorten this, used only for 'time.sleep'.
+        expected_writes = [
+            unittest.mock.call(":STOP\n".encode()),
+            unittest.mock.call(":WAV:FORM BYTE\n".encode()),
+            unittest.mock.call(":WAVeform:LENGth?\n".encode()),
+            unittest.mock.call(f":FILE:SAVE:NAME {name}\n".encode()),
+            unittest.mock.call(f":FILE:SAVE:{expected_type}:EXECute\n".encode()),
+            unittest.mock.call(":START\n".encode()),
+        ]
+        # Act
+        self.yokogawa.save_file(name, waiting_time=waiting_time)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_save_file_ascii(self):
+        """Test save_file method using ascii 'type'."""
+        # Arrange
+        name = "no"
+        expected_type = "ASCii"
+        waiting_time = 0.001  # shorten this, used only for 'time.sleep'.
+        expected_writes = [
+            unittest.mock.call(":STOP\n".encode()),
+            unittest.mock.call(":WAV:FORM BYTE\n".encode()),
+            unittest.mock.call(":WAVeform:LENGth?\n".encode()),
+            unittest.mock.call(f":FILE:SAVE:NAME {name}\n".encode()),
+            unittest.mock.call(f":FILE:SAVE:{expected_type}:EXECute\n".encode()),
+            unittest.mock.call(":START\n".encode()),
+        ]
+        # Act
+        self.yokogawa.save_file(name, type=expected_type.lower(), waiting_time=waiting_time)
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_save_file_excepts(self):
+        """Test the save_file method excepts at wrong file 'type'."""
+        # Arrange
+        name = "no"
+        unexpected_type = "BINasc"
+        expected_writes = [
+            unittest.mock.call(":STOP\n".encode()),
+            unittest.mock.call(":WAV:FORM BYTE\n".encode()),
+            unittest.mock.call(":WAVeform:LENGth?\n".encode()),
+            unittest.mock.call(f":FILE:SAVE:NAME {name}\n".encode()),
+        ]
+        # Act
+        with self.assertRaises(QMI_InstrumentException):
+            self.yokogawa.save_file(name, unexpected_type)
+
+        # Assert
+        self._transport_mock.write.assert_has_calls(expected_writes)
+
+    def test_find_file_name(self):
+        """Test find_file_name method using default 'last' file selection."""
+        # Arrange
+        name = "no"
+        contents = [f"{name.upper()}00{f}.csv" for f in range(8)]
+        label = "007"
+        expected_file_name = name.upper() + label + ".csv"
+        # Act
+        with patch("qmi.instruments.yokogawa.dlm4038.os.listdir", return_value=contents):
+            last_file = self.yokogawa.find_file_name(name)
+
+        # Assert
+        self.assertEqual(expected_file_name, last_file)
+
+    def test_find_file_name_all(self):
+        """Test find_file_name method using 'all' files selection."""
+        # Arrange
+        name = "no"
+        contents = [f"{name.upper()}00{f}.csv" for f in range(8)]
+        expected_file_names = contents
+        # Act
+        with patch("qmi.instruments.yokogawa.dlm4038.os.listdir", return_value=contents):
+            all_files = self.yokogawa.find_file_name(name, "all")
+
+        # Assert
+        self.assertListEqual(expected_file_names, all_files)
+
+    def test_copy_file(self):
+        """Test copy_file method using default 'last' file selection."""
+        # Arrange
+        name = "no"
+        dest = "another_dir"
+        contents = [f"{name.upper()}00{f}.csv" for f in range(8)]
+        label = "007"
+        expected_file_name = name.upper() + label + ".csv"
+        # Act
+        with patch(
+                "qmi.instruments.yokogawa.dlm4038.os.listdir", return_value=contents
+        ), patch("qmi.instruments.yokogawa.dlm4038.shutil.copy") as copy_patch:
+            self.yokogawa.copy_file(name, dest)
+
+        # Assert
+        copy_patch.assert_called_once_with(f"{self.def_path}{expected_file_name}", dest)
+
+    def test_copy_file_all(self):
+        """Test find_file_name method using 'all' files selection."""
+        # Arrange
+        name = "no"
+        dest = "another_dir"
+        contents = [f"{name.upper()}00{f}.csv" for f in range(8)]
+        expected_calls = [
+            unittest.mock.call(f"{self.def_path}{f}", dest) for f in contents
+        ]
+        # Act
+        with patch(
+                "qmi.instruments.yokogawa.dlm4038.os.listdir", return_value=contents
+        ), patch("qmi.instruments.yokogawa.dlm4038.shutil.copy") as copy_patch:
+            self.yokogawa.copy_file(name, dest, "all")
+
+        # Assert
+        copy_patch.assert_has_calls(expected_calls)
+
+    # def test_delete_file(self):
+    #     """Test delete_file method using default 'last' and 'binary' file selections."""
+    #     # Arrange
+    #     name = "no"
+    #     ftype = "BINary"
+    #     contents = [f"{name.upper()}00{f}.csv" for f in range(8)]
+    #     label = "007"
+    #     expected_file_name = name.upper() + label + ".csv"
+    #     # Act
+    #     with patch("qmi.instruments.yokogawa.dlm4038.os.listdir", return_value=contents):
+    #         self.yokogawa.delete_file(name)
+    #
+    #     # Assert
+    #     delete_patch.assert_called_once_with(f"{self.def_path}{expected_file_name}", dest)
+    #
+    # def test_delete_file_all(self):
+    #     """Test find_file_name method using 'all' files selection."""
+    #     # Arrange
+    #     name = "no"
+    #     dest = "another_dir"
+    #     contents = [f"{name.upper()}00{f}.csv" for f in range(8)]
+    #     expected_calls = [
+    #         unittest.mock.call(f"{self.def_path}{f}", dest) for f in contents
+    #     ]
+    #     # Act
+    #     with patch(
+    #             "qmi.instruments.yokogawa.dlm4038.os.listdir", return_value=contents
+    #     ), patch("qmi.instruments.yokogawa.dlm4038.shutil.delete") as delete_patch:
+    #         self.yokogawa.delete_file(name, dest, "all")
+    #
+    #     # Assert
+    #     delete_patch.assert_has_calls(expected_calls)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/instruments/yokogawa/test_dlm4308.py
+++ b/tests/instruments/yokogawa/test_dlm4308.py
@@ -153,7 +153,17 @@ class TestMethodsCase(unittest.TestCase):
         """Test set_high_resolution method with "on"."""
         # Arrange
         high_res = True
-        expected_write = f":ACQUIRE:RESOLUTION {high_res}\n".encode()
+        expected_write = f":ACQUIRE:RESOLUTION ON\n".encode()
+        # Act
+        self.yokogawa.set_high_resolution(high_res)
+        # Assert
+        self._transport_mock.write.assert_called_once_with(expected_write)
+
+    def test_set_high_resolution_off(self):
+        """Test set_high_resolution method with "off"."""
+        # Arrange
+        high_res = False
+        expected_write = f":ACQUIRE:RESOLUTION OFF\n".encode()
         # Act
         self.yokogawa.set_high_resolution(high_res)
         # Assert
@@ -597,7 +607,7 @@ class TestMethodsCase(unittest.TestCase):
         # Arrange
         expected_ndp = int(1.5E6)
         expected_write = b":WAVeform:LENGth?\n"
-        return_value = b"WAVeform:LENG" + f"{expected_ndp}\n".encode()
+        return_value = b"WAVE:LENG:" + f"{expected_ndp}\n".encode()
         self._transport_mock.read_until.return_value = return_value
         # Act
         ndp = self.yokogawa.get_number_data_points()

--- a/tests/instruments/yokogawa/test_dlm4308.py
+++ b/tests/instruments/yokogawa/test_dlm4308.py
@@ -680,18 +680,12 @@ class TestMethodsCase(unittest.TestCase):
         # Arrange
         name = "no"
         unexpected_type = "BINasc"
-        expected_writes = [
-            unittest.mock.call(":STOP\n".encode()),
-            unittest.mock.call(":WAV:FORM BYTE\n".encode()),
-            unittest.mock.call(":WAVeform:LENGth?\n".encode()),
-            unittest.mock.call(f":FILE:SAVE:NAME {name}\n".encode()),
-        ]
         # Act
         with self.assertRaises(QMI_InstrumentException):
             self.yokogawa.save_file(name, unexpected_type)
 
         # Assert
-        self._transport_mock.write.assert_has_calls(expected_writes)
+        self._transport_mock.write.assert_not_called()
 
     def test_find_file_name(self):
         """Test find_file_name method using default 'last' file selection."""
@@ -699,13 +693,13 @@ class TestMethodsCase(unittest.TestCase):
         name = "no"
         contents = [f"{name.upper()}00{f}.csv" for f in range(8)]
         label = "007"
-        expected_file_name = name.upper() + label + ".csv"
+        expected_file_name = [name.upper() + label + ".csv"]
         # Act
         with patch("qmi.instruments.yokogawa.dlm4038.os.listdir", return_value=contents):
             last_file = self.yokogawa.find_file_name(name)
 
         # Assert
-        self.assertEqual(expected_file_name, last_file)
+        self.assertListEqual(expected_file_name, last_file)
 
     def test_find_file_name_all(self):
         """Test find_file_name method using 'all' files selection."""


### PR DESCRIPTION
Ported over and refurbished QMI driver for Yokogawa DLM4038 oscilloscope from Diamondos.

Unit-tests added.
