### PR TITLE
135 make pololu maestro driver be possible to use in uart mode as well

### DIFF
--- a/.github/workflows/scheduled-full-ci.yml
+++ b/.github/workflows/scheduled-full-ci.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Check py-xdrlib installation for Python 3.13
-        if: ${{ matrix.python-version == "3.13" }}
+        if: ${{ matrix.python-version == 3.13 }}
         run: python -m pip install py-xdrlib
 
       - name: Run unit tests and generate report

--- a/.github/workflows/scheduled-full-ci.yml
+++ b/.github/workflows/scheduled-full-ci.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Check py-xdrlib installation for Python 3.13
-        if: ${{ matrix.python-version }} == "3.13"
+        if: ${{ matrix.python-version == "3.13" }}
         run: python -m pip install py-xdrlib
 
       - name: Run unit tests and generate report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.52.0-beta.0] - Unreleased
 
 ### Added
+- Pololu QMI driver can now be used also in UART mode. For this, use of special transport line "uart:<address>[:baudrate=...]" is needed.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- `psutil._common` does not contain `snicaddr` namedtuple since version 7.2.0. It has been moved to `psutil._ntuples`. Fixed this in `proc.py`.
 
 ### Removed
 

--- a/qmi/instruments/pololu/maestro.py
+++ b/qmi/instruments/pololu/maestro.py
@@ -13,7 +13,7 @@ import warnings
 
 # Lazy import of the adafruit-blinka module 'board' and 'QMI_Uart'. See the function _import_modules() below.
 if TYPE_CHECKING:
-    import board
+    import board  # mypy: ignore
     from qmi.instruments.pololu.qmi_uart import QMI_Uart
 else:
     board = None

--- a/qmi/instruments/pololu/maestro.py
+++ b/qmi/instruments/pololu/maestro.py
@@ -13,7 +13,7 @@ import warnings
 
 # Lazy import of the adafruit-blinka module 'board' and 'QMI_Uart'. See the function _import_modules() below.
 if TYPE_CHECKING:
-    import board  # mypy: ignore
+    import board  # type: ignore
     from qmi.instruments.pololu.qmi_uart import QMI_Uart
 else:
     board = None

--- a/qmi/instruments/pololu/maestro.py
+++ b/qmi/instruments/pololu/maestro.py
@@ -1,38 +1,71 @@
 """Instrument driver for the Pololu maestro servo controller"""
 
 import logging
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Generator
 from time import sleep
 
 from qmi.core.context import QMI_Context
 from qmi.core.instrument import QMI_Instrument, QMI_InstrumentIdentification
 from qmi.core.rpc import rpc_method
-from qmi.core.transport import create_transport
+from qmi.core.transport import create_transport, SerialTransportDescriptorParser, QMI_Transport
 from qmi.core.exceptions import QMI_InstrumentException
 import warnings
+
+# Lazy import of the adafruit-blinka module 'board' and 'QMI_Uart'. See the function _import_modules() below.
+if TYPE_CHECKING:
+    import board
+    from qmi.instruments.pololu.qmi_uart import QMI_Uart
+else:
+    board = None
+    QMI_Uart = None
 
 # Global variable holding the logger for this module.
 _logger = logging.getLogger(__name__)
 
 
+def _import_modules() -> None:
+    """Import the adafruit-blinka module and busio extension.
+
+    This import is done in a function, instead of at the top-level,
+    to avoid an unnecessary dependency for programs that do not access
+    the instrument directly.
+    """
+    global board, QMI_Uart
+    if board is None or QMI_Uart is None:
+        import board
+        from qmi.instruments.pololu.qmi_uart import QMI_Uart
+
+
 class Pololu_Maestro(QMI_Instrument):
-    """Instrument driver for the Pololu Maestro servo controller."""
+    """Instrument driver for the Pololu Maestro servo controller.
 
-    # Baudrate of instrument.
+    Note that new devices are delivered standard in UART mode. If the user wishes to use the device
+    in USB Dual Port or USB Chained serial mode, the mode has to be changed with the Pololu's
+    Maestro Control Center program.
+
+    Attributes:
+        BAUDRATE:                 Default Baudrate of instrument with serial connection.
+        RESPONSE_TIMEOUT:         Default response timeout for I/O actions.
+        DEFAULT_NUM_CHANNELS:     Default number of channels.
+        DEFAULT_MIN_VALUE:        Default minimum settable target and speed values.
+        DEFAULT_MAX_VALUE:        Default maximum settable target and speed values.
+        DEFAULT_MIN_ACCELERATION: Default minimum acceleration.
+        DEFAULT_MAX_ACCELERATION: Default maximum acceleration.
+    """
+    _rpc_constants = [
+        "BAUDRATE",
+        "RESPONSE_TIMEOUT",
+        "DEFAULT_NUM_CHANNELS",
+        "DEFAULT_MIN_VALUE",
+        "DEFAULT_MAX_VALUE",
+        "DEFAULT_MIN_ACCELERATION",
+        "DEFAULT_MAX_ACCELERATION",
+    ]
     BAUDRATE = 9600
-
-    # Instrument should respond within 2 seconds.
     RESPONSE_TIMEOUT = 2.0
-
-    # Default number of channels.
     DEFAULT_NUM_CHANNELS = 6
-
-    # Default minimum and maximum settable values.
-    # These are determined by the bit lengths for the values (16 bits)
     DEFAULT_MIN_VALUE = 0
     DEFAULT_MAX_VALUE = 16383
-
-    # Default minimum and maximum accleration.
     DEFAULT_MIN_ACCELERATION = 0
     DEFAULT_MAX_ACCELERATION = 255
 
@@ -72,11 +105,12 @@ class Pololu_Maestro(QMI_Instrument):
     }
 
     def __init__(
-            self, context: QMI_Context, name: str, transport: str, num_channels: int = DEFAULT_NUM_CHANNELS,
-            channels_min_max_targets: Optional[Dict[int, Tuple[int, int]]] = None,
-            channels_min_max_speeds: Optional[Dict[int, Tuple[int, int]]] = None,
-            channels_min_max_accelerations: Optional[Dict[int, Tuple[int, int]]] = None) -> None:
-        """Initialize driver.
+        self, context: QMI_Context, name: str, transport: str, num_channels: int = DEFAULT_NUM_CHANNELS,
+        channels_min_max_targets: None | dict[int, tuple[int, int]] = None,
+        channels_min_max_speeds: None | dict[int, tuple[int, int]] = None,
+        channels_min_max_accelerations: None | dict[int, tuple[int, int]] = None
+    ) -> None:
+        """Initialize driver. This driver can be used for Pololu Micro Maestro in UART or Dual Port USB modes.
 
         Parameters:
             context:                        The QMI context
@@ -91,41 +125,47 @@ class Pololu_Maestro(QMI_Instrument):
                                             of the min and max.
         """
         super().__init__(context, name)
-        self._transport = create_transport(transport, default_attributes={
-                                           "baudrate": self.BAUDRATE})
+        self._transport: QMI_Transport | QMI_Uart
+        if transport.lower().startswith("uart"):
+            # import modules
+            _import_modules()
+            # Do a manual parsing of the transport string
+            transport = transport.lower().replace("uart", "serial")
+            parsed_transport_dict = SerialTransportDescriptorParser.parse_parameter_strings(transport)
+            baudrate = parsed_transport_dict["baudrate"] if "baudrate" in parsed_transport_dict else self.BAUDRATE
+            self._transport = QMI_Uart(board.TX, board.RX, baudrate)
+        else:
+            self._transport = create_transport(transport, default_attributes={"baudrate": self.BAUDRATE})
+
         # This device number defaults to 0x0C (or 12 in decimal).
         device_nr = 0x0C
         # Command lead-in and device number are sent for each Pololu serial command.
         self._cmd_lead_in = chr(0xAA) + chr(device_nr)
         # Track the target value of each channel
-        self._targets: List[int] = [0] * num_channels
+        self._targets: list[int] = [0] * num_channels
         # Store the minimum and maximum target values of each channel
-        self._min_target_values: List[int] = [
-            self.DEFAULT_MIN_VALUE] * num_channels
-        self._max_target_values: List[int] = [
-            self.DEFAULT_MAX_VALUE] * num_channels
+        self._min_target_values: list[int] = [self.DEFAULT_MIN_VALUE] * num_channels
+        self._max_target_values: list[int] = [self.DEFAULT_MAX_VALUE] * num_channels
 
-        channels_min_max_targets = channels_min_max_targets if channels_min_max_targets else {}
-        channels_min_max_speeds = channels_min_max_speeds if channels_min_max_speeds else {}
-        channels_min_max_accelerations = channels_min_max_accelerations if channels_min_max_accelerations else {}
+        channels_min_max_targets = channels_min_max_targets or {}
+        channels_min_max_speeds = channels_min_max_speeds or {}
+        channels_min_max_accelerations = channels_min_max_accelerations or {}
         # Overwrite channels that have a provided min/max target value
         for c in channels_min_max_targets.keys():
             self._min_target_values[c] = channels_min_max_targets[c][0]
             self._max_target_values[c] = channels_min_max_targets[c][1]
+
         # Store the minimum and maximum speeds of each channel
-        self._min_speeds: List[int] = [
-            self.DEFAULT_MIN_VALUE] * num_channels
-        self._max_speeds: List[int] = [
-            self.DEFAULT_MAX_VALUE] * num_channels
+        self._min_speeds: list[int] = [self.DEFAULT_MIN_VALUE] * num_channels
+        self._max_speeds: list[int] = [self.DEFAULT_MAX_VALUE] * num_channels
         # Overwrite channels that have a provided min/max speed
         for c in channels_min_max_speeds.keys():
             self._min_speeds[c] = channels_min_max_speeds[c][0]
             self._max_speeds[c] = channels_min_max_speeds[c][1]
+
         # Store the minimum and maximum accelerations of each channel
-        self._min_accelerations: List[int] = [
-            self.DEFAULT_MIN_ACCELERATION] * num_channels
-        self._max_accelerations: List[int] = [
-            self.DEFAULT_MAX_ACCELERATION] * num_channels
+        self._min_accelerations: list[int] = [self.DEFAULT_MIN_ACCELERATION] * num_channels
+        self._max_accelerations: list[int] = [self.DEFAULT_MAX_ACCELERATION] * num_channels
         # Overwrite channels that have a provided min/max acceleration
         for c in channels_min_max_accelerations.keys():
             self._min_accelerations[c] = channels_min_max_accelerations[c][0]
@@ -141,6 +181,9 @@ class Pololu_Maestro(QMI_Instrument):
         Parameters:
             channel:    Channel number.
             value:      Value for the command.
+
+        Returns:
+            command: Four-character compiled command string "<cmd><channel><LSB><MSB>".
         """
         lsb = value & 0x7F
         msb = (value >> 7) & 0x7F
@@ -157,17 +200,16 @@ class Pololu_Maestro(QMI_Instrument):
             yield bit
             num ^= bit
 
-    def _get_errors(self) -> List[str]:
+    def _get_errors(self) -> list[str]:
         """Get errors.
 
         Returns:
-            List of errors.
+            list of errors.
         """
         self._transport.discard_read()  # Discard possible read buffer
         cmd = self._cmd_lead_in + chr(0x21)
         self._transport.write(bytes(cmd, "latin-1"))
-        bin_err = self._transport.read(
-            nbytes=2, timeout=self.RESPONSE_TIMEOUT)
+        bin_err = self._transport.read_until_timeout(nbytes=2, timeout=self.RESPONSE_TIMEOUT)
         int_err = int.from_bytes(bin_err, "big")
         errors = []
         # loop over bits and log the errors
@@ -191,7 +233,8 @@ class Pololu_Maestro(QMI_Instrument):
         if errs:
             formatted_errs = '\n'.join(map(str, errs))
             raise QMI_InstrumentException(
-                f"Pololu Maestro servo command {cmd} resulted in the following error(s).\n{formatted_errs}")
+                f"Pololu Maestro servo command {cmd} resulted in the following error(s).\n{formatted_errs}"
+            )
 
     def _ask(self, cmd: str) -> int:
         """Send ask command to instrument.
@@ -200,26 +243,25 @@ class Pololu_Maestro(QMI_Instrument):
             cmd: The command string to be written.
 
         Raises:
-            QMI_InstrumentException if the servo command returns an error.
+            QMI_InstrumentException: If the servo command returns an error.
 
         Returns:
-            The queried value.
+            sum_msb_lsb: The queried value.
         """
         cmd = self._cmd_lead_in + cmd
         self._transport.write(bytes(cmd, "latin-1"))
         # Sleep over the bits to be sent
         sleep(len(cmd) / self.BAUDRATE * 100)
         # Read back the response bits
-        lsb = ord(self._transport.read(
-            nbytes=1, timeout=self.RESPONSE_TIMEOUT))
-        msb = ord(self._transport.read(
-            nbytes=1, timeout=self.RESPONSE_TIMEOUT))
+        lsb = ord(self._transport.read_until_timeout(nbytes=1, timeout=self.RESPONSE_TIMEOUT))
+        msb = ord(self._transport.read_until_timeout(nbytes=1, timeout=self.RESPONSE_TIMEOUT))
 
         errs = self._get_errors()
         if errs:
             formatted_errs = '\n'.join(map(str, errs))
             raise QMI_InstrumentException(
-                f"Pololu Maestro servo command {cmd} resulted in the following error(s).\n{formatted_errs}")
+                f"Pololu Maestro servo command {cmd} resulted in the following error(s).\n{formatted_errs}"
+            )
 
         return (msb << 8) + lsb
 
@@ -260,7 +302,7 @@ class Pololu_Maestro(QMI_Instrument):
     def set_target(self, channel: int, value: int) -> None:
         """Set channel to a specified target value. The target value is of units 0.25us. For example, if you want to
         set the target to 1500 us, you need to give as input 6000:
-        (1500×4 = 6000 = 01011101110000 in binary)
+        (1500×4 = 6000 = 01011101110000 in binary).
         Servo will begin moving based on speed and acceleration parameters previously set.
         This method will check against the maximum and minimum target value of the channel. If the value to be set is
         out of the min/max range, the method will set the target value to the min/max.
@@ -287,11 +329,11 @@ class Pololu_Maestro(QMI_Instrument):
         self._targets[channel] = target
 
     @rpc_method
-    def get_targets(self) -> List[int]:
+    def get_targets(self) -> list[int]:
         """Get the current targets for each channel.
 
         Returns:
-            The target values for each channel.
+            self_targets: The target values for each channel.
         """
         return self._targets
 
@@ -303,7 +345,7 @@ class Pololu_Maestro(QMI_Instrument):
             channel: The channel number.
 
         Returns:
-            The position in quarter-microsecond units.
+            position: The position in quarter-microsecond units.
         """
         self._check_is_open()
         self._check_channel(channel)
@@ -321,7 +363,7 @@ class Pololu_Maestro(QMI_Instrument):
             speed:      The target speed.
 
         Raises:
-            ValueError if speed is out of allowable range.
+            ValueError: If speed is out of allowable range.
         """
         self._check_is_open()
         self._check_channel(channel)
@@ -344,7 +386,7 @@ class Pololu_Maestro(QMI_Instrument):
             acceleration:   The target acceleration.
 
         Raises:
-            ValueError if acceleration not within 0 to 255
+            ValueError: If acceleration not within 0 to 255.
         """
         self._check_is_open()
         self._check_channel(channel)
@@ -358,7 +400,7 @@ class Pololu_Maestro(QMI_Instrument):
         self._write(cmd)
 
     @rpc_method
-    def go_home(self):
+    def go_home(self) -> None:
         """Send all servos and outputs to their home values."""
         self._check_is_open()
         self._write(chr(0x22))
@@ -370,11 +412,15 @@ class Pololu_Maestro(QMI_Instrument):
         Parameters:
             channel:    The channel number.
             value:      The new minimum target value.
+
+        Raises:
+            ValueError: If minimum target value is not in valid range.
         """
         if value < self.DEFAULT_MIN_VALUE or value > self._max_target_values[channel]:
             raise ValueError(
-                f"Minimum value invalid, should be in range [{self.DEFAULT_MIN_VALUE},\
-                    {self._max_target_values[channel]}")
+                f"Minimum value invalid, should be in range [{self.DEFAULT_MIN_VALUE}," +
+                    f"{self._max_target_values[channel]}]"
+            )
 
         self._min_target_values[channel] = value
 
@@ -384,6 +430,9 @@ class Pololu_Maestro(QMI_Instrument):
 
         Parameters:
             channel:    The channel number.
+
+        Returns:
+            min_target_value: The queried value.
         """
         return self._min_target_values[channel]
 
@@ -394,11 +443,15 @@ class Pololu_Maestro(QMI_Instrument):
         Parameters:
             channel:    The channel number.
             value:      The new maximum target value.
+
+        Raises:
+            ValueError: If given maximum target value is not in valid range.
         """
         if value <= self._min_target_values[channel] or value > self.DEFAULT_MAX_VALUE:
             raise ValueError(
-                f"Maximum value invalid, should be in range [{self._min_target_values[channel] + 1},\
-                    {self.DEFAULT_MAX_VALUE}]")
+                f"Maximum value invalid, should be in range [{self._min_target_values[channel] + 1}," +
+                    f"{self.DEFAULT_MAX_VALUE}]"
+            )
 
         self._max_target_values[channel] = value
 
@@ -408,6 +461,9 @@ class Pololu_Maestro(QMI_Instrument):
 
         Parameters:
             channel:    The channel number.
+
+        Returns:
+            max_target_value: The queried maximum target value.
         """
         return self._max_target_values[channel]
 
@@ -421,7 +477,8 @@ class Pololu_Maestro(QMI_Instrument):
         """
         warnings.warn(
             f"{self.set_max.__name__} has been deprecated. Please use {self.set_max_target.__name__}.",
-            DeprecationWarning)
+            DeprecationWarning
+        )
         self.set_max_target(channel, value)
 
     @rpc_method
@@ -434,14 +491,15 @@ class Pololu_Maestro(QMI_Instrument):
         """
         warnings.warn(
             f"{self.set_min.__name__} has been deprecated. Please use {self.set_min_target.__name__}.",
-            DeprecationWarning)
+            DeprecationWarning
+        )
         self.set_min_target(channel, value)
 
     @rpc_method
     def set_target_value(self, channel: int, value: int) -> None:
         """Set channel to a specified target value. The target value is of units 0.25us. For example, if you want to
         set the target to 1500 us, you need to give as input 6000:
-        (1500×4 = 6000 = 01011101110000 in binary)
+        (1500×4 = 6000 = 01011101110000 in binary).
         Servo will begin moving based on speed and acceleration parameters previously set.
         This method will check against the maximum and minimum target value of the channel. If the value to be set is
         out of the min/max range, the method will set the target value to the min/max.
@@ -479,7 +537,8 @@ class Pololu_Maestro(QMI_Instrument):
         """
         warnings.warn(
             f"{self.move_up.__name__} has been deprecated. There is no replacement for this.",
-            DeprecationWarning)
+            DeprecationWarning
+        )
 
     @rpc_method
     def move_down(self, channel: int) -> None:
@@ -490,4 +549,5 @@ class Pololu_Maestro(QMI_Instrument):
         """
         warnings.warn(
             f"{self.move_down.__name__} has been deprecated. There is no replacement for this.",
-            DeprecationWarning)
+            DeprecationWarning
+        )

--- a/qmi/instruments/pololu/maestro.py
+++ b/qmi/instruments/pololu/maestro.py
@@ -24,11 +24,10 @@ _logger = logging.getLogger(__name__)
 
 
 def _import_modules() -> None:
-    """Import the adafruit-blinka module and busio extension.
+    """Import the adafruit-blinka modules 'board', and 'busio' in qmi_uart.py.
 
-    This import is done in a function, instead of at the top-level,
-    to avoid an unnecessary dependency for programs that do not access
-    the instrument directly.
+    This import is done in a function, instead of at the top-level, to avoid an unnecessary dependency for programs
+    that do not access the instrument directly.
     """
     global board, QMI_Uart
     if board is None or QMI_Uart is None:
@@ -39,7 +38,9 @@ def _import_modules() -> None:
 class Pololu_Maestro(QMI_Instrument):
     """Instrument driver for the Pololu Maestro servo controller.
 
-    Note that new devices are delivered standard in UART mode. If the user wishes to use the device
+    Note that new devices are delivered standard in UART mode. The UART mode can be used by this driver by providing a
+    special transport string, f.ex. "uart:COMx:baudrate=115200". The device address (COM port number in this example)
+    is ignored by the driver in UART mode, but needed for parsing the string. If the user wishes to use the device
     in USB Dual Port or USB Chained serial mode, the mode has to be changed with the Pololu's
     Maestro Control Center program.
 
@@ -134,6 +135,7 @@ class Pololu_Maestro(QMI_Instrument):
             parsed_transport_dict = SerialTransportDescriptorParser.parse_parameter_strings(transport)
             baudrate = parsed_transport_dict["baudrate"] if "baudrate" in parsed_transport_dict else self.BAUDRATE
             self._transport = QMI_Uart(board.TX, board.RX, baudrate)
+
         else:
             self._transport = create_transport(transport, default_attributes={"baudrate": self.BAUDRATE})
 

--- a/qmi/instruments/pololu/qmi_uart.py
+++ b/qmi/instruments/pololu/qmi_uart.py
@@ -1,0 +1,98 @@
+import time
+
+import busio
+
+from qmi.core.exceptions import QMI_InvalidOperationException
+
+
+class QMI_Uart(busio.UART):
+    """Extension of the class to make compatible with QMI_Transport calls.
+
+    Attributes:
+        READ_BYTE_BATCH_SIZE: The default size of the read buffer, based on <LSB><MSB>.
+    """
+    READ_BYTE_BATCH_SIZE = 2
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(args, kwargs)
+        self._is_open = True
+
+    def _check_is_open(self) -> None:
+        """Verify that the transport is open, otherwise raise exception."""
+        if not self._is_open:
+            raise QMI_InvalidOperationException(
+                f"Operation not allowed on closed transport {type(self).__name__}")
+
+    def open(self) -> None:
+        """The instrument is opened already at the __init__."""
+        pass
+
+    def close(self) -> None:
+        """Close the transport and de-initialize the device."""
+        self._check_is_open()
+        self.deinit()
+        self._is_open = False
+
+    def write(self, data: bytes) -> None:
+        """Write a sequence of bytes to the transport.
+
+        When this method returns, all bytes are written to the transport
+        or queued to be written to the transport.
+
+        An exception is raised if the transport is closed from the remote
+        side before all bytes could be written.
+
+        Subclasses must override this method, if applicable.
+        """
+        self._check_is_open()
+        super().write(data)
+
+    def read_until_timeout(self, nbytes: int, timeout: float) -> bytes:
+        """Read a sequence of bytes from the transport.
+
+        This method blocks until either the specified number of bytes
+        are available or the timeout (in seconds) expires, whichever occurs
+        sooner.
+
+        If timeout occurs, the partial sequence of available bytes is returned.
+        This sequence may be empty if timeout occurs before any byte was available.
+
+        If the transport has been closed on the remote side, any remaining
+        input bytes are returned (up to the maximum number of bytes requested).
+        If there are no more bytes to read, QMI_EndOfInputException is raised.
+
+        Subclasses must override this method, if applicable.
+
+        Parameters:
+            nbytes:  Maximum number of bytes to read.
+            timeout: Maximum time to wait (in seconds).
+
+        Returns:
+            Received bytes.
+
+        Raises:
+            ~qmi.core.exceptions.QMI_EndOfInputException: If the transport has been closed on
+                the remote side and there are no more bytes to read.
+        """
+        self._check_is_open()
+        buffer = bytearray()
+        batch = self.READ_BYTE_BATCH_SIZE
+        bytes_read = 0
+        start_time = time.time()
+        while bytes_read < nbytes:
+            # Extend buffer, for now try in batches of 4 bytes.
+            self.readinto(buffer, nbytes=batch)
+            bytes_read += batch
+            # Check on remaining buffer and adjust read batch size if necessary.
+            if bytes_read + batch > nbytes:
+                self.readinto(buffer, nbytes=nbytes - bytes_read)
+                break
+
+            if time.time() - start_time > timeout:
+                break
+
+        return bytes(buffer)
+
+    def discard_read(self) -> None:
+        """Discard all bytes that are immediately available for reading."""
+        self.readline()  # Warning! This might block if there is nothing to read.

--- a/qmi/instruments/pololu/qmi_uart.py
+++ b/qmi/instruments/pololu/qmi_uart.py
@@ -1,6 +1,6 @@
 import time
 
-import busio
+import busio  # mypy: ignore
 
 from qmi.core.exceptions import QMI_InvalidOperationException
 

--- a/qmi/instruments/pololu/qmi_uart.py
+++ b/qmi/instruments/pololu/qmi_uart.py
@@ -1,6 +1,6 @@
 import time
 
-import busio  # mypy: ignore
+import busio  # type: ignore
 
 from qmi.core.exceptions import QMI_InvalidOperationException
 

--- a/qmi/instruments/pololu/qmi_uart.py
+++ b/qmi/instruments/pololu/qmi_uart.py
@@ -74,7 +74,7 @@ class QMI_Uart(busio.UART):
             timeout: Maximum time to wait (in seconds).
 
         Returns:
-            data: Received bytes.
+            buffer: Received bytes.
         """
         self._check_is_open()
         buffer = bytearray()

--- a/qmi/tools/proc.py
+++ b/qmi/tools/proc.py
@@ -53,6 +53,8 @@ if __name__ == "__main__":
 else:
     _logger = logging.getLogger(__name__)
 
+# psutil version info
+V, R, _ = map(int, psutil.__version__.split("."))
 
 # Result from shutdown_context().
 ShutdownResult = NamedTuple("ShutdownResult", [
@@ -253,8 +255,7 @@ def is_local_host(host: str) -> bool:
     # Return True if a local IP address matches the specified host.
     for addrs in if_addrs.values():
         for addr in addrs:
-            v, r, _ = map(int, psutil.__version__.split("."))
-            if (v == 7 and r >= 2) or v > 7:
+            if (V == 7 and R >= 2) or V > 7:
                 assert isinstance(addr, psutil._ntuples.snicaddr)
             else:
                 assert isinstance(addr, psutil._common.snicaddr)

--- a/qmi/tools/proc.py
+++ b/qmi/tools/proc.py
@@ -253,7 +253,12 @@ def is_local_host(host: str) -> bool:
     # Return True if a local IP address matches the specified host.
     for addrs in if_addrs.values():
         for addr in addrs:
-            assert isinstance(addr, psutil._common.snicaddr)
+            v, r, _ = map(int, psutil.__version__.split("."))
+            if (v == 7 and r >= 2) or v > 7:
+                assert isinstance(addr, psutil._ntuples.snicaddr)
+            else:
+                assert isinstance(addr, psutil._common.snicaddr)
+
             if addr.address in host_ips:
                 return True
 

--- a/tests/instruments/pololu/test_qmi_uart.py
+++ b/tests/instruments/pololu/test_qmi_uart.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import Mock, patch, call
+
+
+class UART_stub:
+    def __init__(self, *args, **kwargs):
+        self.deinit_called = False
+        self.write_buffer = bytearray()
+        self.read_buffer = bytearray()
+
+    def deinit(self):
+        self.deinit_called = True
+
+    def write(self, data: bytes):
+        self.write_buffer += list(data)
+
+    def readinto(self, buf: bytearray, nbytes: int):
+        return buf + bytearray(int(f"{self.read_buffer.pop(0)}").to_bytes())
+
+    def readline(self):
+        try:
+            return self.read_buffer
+        finally:
+            self.read_buffer = bytearray()
+
+
+busio_mock = Mock()
+busio_mock.UART = UART_stub
+with patch.dict("sys.modules", {"busio": busio_mock}) as sys_patch:
+    from qmi.instruments.pololu.qmi_uart import QMI_Uart
+
+
+class QmiUartTestCase(unittest.TestCase):
+    def setUp(self):
+        self.uart_mock = Mock()
+
+    def test_something(self):
+        busio_mock.UART = self.uart_mock
+        qmi_uart = QMI_Uart()
+        qmi_uart.open()
+
+        self.assertTrue(qmi_uart._is_open)
+
+        qmi_uart.close()
+
+        self.assertFalse(qmi_uart._is_open)
+
+        busio_mock.UART.deinit.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/instruments/pololu/test_qmi_uart.py
+++ b/tests/instruments/pololu/test_qmi_uart.py
@@ -1,9 +1,31 @@
+from queue import Empty
 import unittest
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, patch
 
 
 class UART_stub:
+
+    class _Uart:
+
+        class Nova:
+
+            class RxdQueue:
+                block_count = 0
+                def get(self, block):
+                    if self.block_count:
+                        raise Empty()
+
+                    self.block_count += 1
+                    return b"\r"
+
+            def __init__(self):
+                self._rxdQueue = self.RxdQueue()
+
+        def __init__(self):
+            self._nova = self.Nova()
+
     def __init__(self, *args, **kwargs):
+        self._uart = self._Uart()
         self.deinit_called = False
         self.write_buffer = bytearray()
         self.read_buffer = bytearray()
@@ -12,16 +34,13 @@ class UART_stub:
         self.deinit_called = True
 
     def write(self, data: bytes):
-        self.write_buffer += list(data)
+        self.write_buffer += bytearray(data)
 
     def readinto(self, buf: bytearray, nbytes: int):
-        return buf + bytearray(int(f"{self.read_buffer.pop(0)}").to_bytes())
+        for _ in range(nbytes):
+            buf += bytearray(int(f"{self.read_buffer.pop(0)}").to_bytes())
 
-    def readline(self):
-        try:
-            return self.read_buffer
-        finally:
-            self.read_buffer = bytearray()
+        return buf
 
 
 busio_mock = Mock()
@@ -32,20 +51,62 @@ with patch.dict("sys.modules", {"busio": busio_mock}) as sys_patch:
 
 class QmiUartTestCase(unittest.TestCase):
     def setUp(self):
-        self.uart_mock = Mock()
+        self.qmi_uart = QMI_Uart()
 
-    def test_something(self):
-        busio_mock.UART = self.uart_mock
-        qmi_uart = QMI_Uart()
-        qmi_uart.open()
+    def test_open_close(self):
+        """Simple open-close test."""
+        self.qmi_uart.open()
 
-        self.assertTrue(qmi_uart._is_open)
+        self.assertTrue(self.qmi_uart._is_open)
+        self.assertFalse(self.qmi_uart.deinit_called)
 
-        qmi_uart.close()
+        self.qmi_uart.close()
 
-        self.assertFalse(qmi_uart._is_open)
+        self.assertFalse(self.qmi_uart._is_open)
+        self.assertTrue(self.qmi_uart.deinit_called)
 
-        busio_mock.UART.deinit.assert_called_once_with()
+    def test_write(self):
+        """Test write function."""
+        data = b"01234"
+        expected_write = bytearray(data)
+        self.qmi_uart.write(data)
+        self.qmi_uart.close()
+
+        self.assertEqual(expected_write, self.qmi_uart.write_buffer)
+
+    def test_read_until_timeout(self):
+        """Test read_until_timeout function."""
+        expected_read = b"01234"
+        data = bytearray(expected_read)
+        self.qmi_uart.read_buffer = data
+
+        # First read two bytes
+        retval = self.qmi_uart.read_until_timeout(2, 1.0)
+        self.assertEqual(expected_read[:2], retval)
+        # Then try to read 3 bytes, where we are limited by timeout and batch size, and get back only 2.
+        retval_2 = self.qmi_uart.read_until_timeout(3, 0.0)
+        self.assertEqual(expected_read[2:4], retval_2)
+        # Replenish buffer
+        self.qmi_uart.read_buffer = data
+
+    def test_read_until_timeout_batch_size_check(self):
+        """Test read_until_timeout function with read 5 bytes,
+        which triggers the check on remaining buffer size vs batch size.
+        """
+        expected_read = b"01234"
+        data = bytearray(expected_read)
+        self.qmi_uart.read_buffer = data
+
+        retval = self.qmi_uart.read_until_timeout(5, 1.0)
+        self.assertEqual(expected_read, retval)
+
+        self.qmi_uart.close()
+
+    def test_discard_read(self):
+        """Test discard_read to see it reads from "queue"."""
+        self.assertEqual(0, self.qmi_uart._uart._nova._rxdQueue.block_count)
+        self.qmi_uart.discard_read()
+        self.assertEqual(1, self.qmi_uart._uart._nova._rxdQueue.block_count)
 
 
 if __name__ == '__main__':

--- a/tests/tools/test_proc.py
+++ b/tests/tools/test_proc.py
@@ -389,6 +389,7 @@ class QmiProcMethodsTestCase(unittest.TestCase):
             "some_if": ["foute_addr"]
         })
         psutil_patch.net_if_addrs = net_if_addrs
+        psutil_patch.__version__ = psutil.__version__
         v, r, _ = map(int, psutil.__version__.split("."))
         if (v == 7 and r >= 2) or v > 7:
             psutil_patch._ntuples.snicaddr = psutil._ntuples.snicaddr

--- a/tests/tools/test_proc.py
+++ b/tests/tools/test_proc.py
@@ -389,7 +389,11 @@ class QmiProcMethodsTestCase(unittest.TestCase):
             "some_if": ["foute_addr"]
         })
         psutil_patch.net_if_addrs = net_if_addrs
-        psutil_patch._common.snicaddr = psutil._common.snicaddr
+        v, r, _ = map(int, psutil.__version__.split("."))
+        if (v == 7 and r >= 2) or v > 7:
+            psutil_patch._ntuples.snicaddr = psutil._ntuples.snicaddr
+        else:
+            psutil_patch._common.snicaddr = psutil._common.snicaddr
         # Except first the second assertion
         with self.assertRaises(AssertionError) as ass_err_2:
             proc.is_local_host("123.45.67.89")


### PR DESCRIPTION
Pololu Maestro QMI driver was updated so that it can be used also with Pololu instruments that are in the default UART mode, by using a special "uart:..." transport string. For this we need `board` and `busio` modules from `adafruit-blinka` package, which are imported as "lazy imports". The latter is imported through new `qmi_uart` module, which has an extension of the `busio.UART` class so that it is compatible with `QMI_Transport` classes to use with the special transport string, and to use the same read-write calls.

During the course of this refactoring and extension, also the `psutil` package was updated such that it would not work anymore in `qmi_proc.py`. This is due to moving the `_snicaddr` internal variable in the package. The `qmi_proc.py` was adapted such that it checks the version number of  `psutil` and selects followingly the correct location of the `_snicaddr`.