### PR TITLE
Bump version: 0.53.0-beta.0 → 0.54.0-beta.0

### DIFF
--- a/.bumpversion_main.toml
+++ b/.bumpversion_main.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.53.0-beta.0"
+current_version = "0.54.0-beta.0"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\-(?P<release>[a-z]+))?(\\.(?P<build>\\d+))?"
@@ -31,7 +31,7 @@ filename = "qmi/__init__.py"
 
 [[tool.bumpversion.files]]
 filename = "CHANGELOG.md"
-search = "[{current_version}] - Unreleased"
+search = "[VERSION] - Unreleased"
 replace = "[{new_version}] - Unreleased"
 
 [[tool.bumpversion.files]]

--- a/.bumpversion_release.toml
+++ b/.bumpversion_release.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.53.0-beta.0"
+current_version = "0.54.0-beta.0"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\-(?P<release>[a-z]+))?(\\.(?P<build>\\d+))?"

--- a/.bumpversion_stable.toml
+++ b/.bumpversion_stable.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.53.0-beta.0"
+current_version = "0.54.0-beta.0"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\-(?P<release>[a-z]+))?(\\.(?P<build>\\d+))?"

--- a/.bumpversion_switch.toml
+++ b/.bumpversion_switch.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.53.0-beta.0"
+current_version = "0.54.0-beta.0"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\-(?P<release>[a-z]+))?(\\.(?P<build>\\d+))?"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.53.0-beta.0] - Unreleased
+## [0.54.0-beta.0] - Unreleased
+
+## [0.53.0] - 2026-05-11
 
 ### Added
 - Functions to `qmi.instruments.yokogawa.dlm4308` for obtaining trace data from the instrument waveform channels via Ethernet. All data formats are enabled.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -97,5 +97,5 @@ keywords:
   - Quantum
   - Software
 license: MIT
-version: v0.53.0-beta.0
+version: v0.54.0-beta.0
 date-released: '2026-04-01'

--- a/documentation/sphinx/source/conf.py
+++ b/documentation/sphinx/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2024, QuTech — Delft, The Netherlands'
 author = 'QuTech'
 
 # The full version, including alpha/beta/rc tags
-release = '0.53.0-beta.0'
+release = '0.54.0-beta.0'
 
 # The default master_doc used to be 'index', but it was changed to 'contents'.
 # Override that here (maybe rename the file to the new default later).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ Issues = "https://github.com/QuTech-Delft/QMI/issues"
 
 [project]
 name="qmi"
-version="0.53.0-beta.0"
+version="0.54.0-beta.0"
 description="The Quantum Measurement Infrastructure framework"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE.md"}

--- a/qmi/__init__.py
+++ b/qmi/__init__.py
@@ -7,7 +7,7 @@ import os
 import atexit
 
 
-__version__ = "0.53.0-beta.0"
+__version__ = "0.54.0-beta.0"
 
 
 # Check Python version.


### PR DESCRIPTION
Bumping version tags after release.