### PR TITLE
Qblox qmi driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.54.0-beta.0] - Unreleased
 
+### Added
+- QMI driver for Qblox cluster series device, with support for QCM[-RF], QRM[-RF] and QTM modules.
+
 ## [0.53.0] - 2026-05-11
 
 ### Added

--- a/qmi/instruments/qblox/__init__.py
+++ b/qmi/instruments/qblox/__init__.py
@@ -1,3 +1,16 @@
+"""
+Qblox B.V.; Cluster series.
+
+The qmi.instruments.qblox package provides support for:
+- Qblox cluster series with modules::
+  - [C]MM
+  - QCM
+  - QRM
+  - QCM-RF
+  - QRM-RF
+  - QTM
+"""
+
 from qmi.instruments.qblox.cluster import Qblox_NativeCluster as Qblox_NativeCluster
 from qmi.instruments.qblox.cluster import Qblox_QcodesCluster as Qblox_QcodesCluster
 from qmi.instruments.qblox.cluster import SEQUENCERS_IN_MODULE as SEQUENCERS_IN_MODULE

--- a/qmi/instruments/qblox/__init__.py
+++ b/qmi/instruments/qblox/__init__.py
@@ -1,0 +1,6 @@
+from qmi.instruments.qblox.cluster import Qblox_NativeCluster as Qblox_NativeCluster
+from qmi.instruments.qblox.cluster import Qblox_QcodesCluster as Qblox_QcodesCluster
+from qmi.instruments.qblox.cluster import SEQUENCERS_IN_MODULE as SEQUENCERS_IN_MODULE
+from qmi.instruments.qblox.cluster import AI_IN_MODULE as AI_IN_MODULE
+from qmi.instruments.qblox.cluster import AO_IN_MODULE as AO_IN_MODULE
+from qmi.instruments.qblox.cluster import DIGITAL_MARKERS_IN_MODULE as DIGITAL_MARKERS_IN_MODULE

--- a/qmi/instruments/qblox/cluster.py
+++ b/qmi/instruments/qblox/cluster.py
@@ -1,0 +1,903 @@
+# mypy: disable-error-code=import-untyped
+# mypy: disable-error-code=import-not-found
+"""This module is for Qblox cluster control. It requires qblox_instruments 1.1.0 or newer."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import inspect
+import logging
+import sys
+from functools import partial
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import qblox_instruments
+    from qblox_instruments import Cluster
+    from qblox_instruments.native import Cluster as NativeCluster
+    from qblox_instruments.native.helpers import ChannelMapCache
+    from qblox_instruments.qcodes_drivers.module import Module as QcodesModule
+    from qblox_instruments.scpi.layers.cluster_mm_1_0 import Cluster as ScpiCluster
+    from qblox_instruments.types import DebugLevel
+
+else:
+    qblox_instruments = None
+    Cluster, NativeCluster, ScpiCluster = None, None, None
+    ChannelMapCache, QcodesModule, DebugLevel = None, None, None
+
+from qmi.core.context import QMI_Context
+from qmi.core.instrument import QMI_Instrument
+from qmi.core.rpc import rpc_method
+
+_logger = logging.getLogger(__name__)
+
+DEBUG_LEVEL: Any = None
+_EXTRA_ATTRS = [
+    "_get_sequencer_channel_map",
+    "_get_sequencer_acq_channel_map",
+    "_get_sequencer_state",
+    "_set_sequencer_channel_map",
+    "_set_sequencer_acq_channel_map",
+    "_set_acq_acquisition_data",
+    "_delete_awg_waveform",
+    "_delete_acq_weight",
+    "_delete_acq_acquisition",
+    "_delete_acq_acquisition_data",
+    "_add_acq_acquisition",
+    "_add_awg_waveform",
+    "_set_acq_acquisition_index",
+    "_set_awg_waveform_data",
+    "_set_awg_waveform_index",
+]
+
+# The amount of (external) trigger addresses in a cluster
+EXT_TRIGGERS_IN_CLUSTER = 15
+# Module configuration constants:
+# AO_IN_MODULE:              Analog output channels in modules with value range -1V...+1V.
+# AI_IN_MODULE:              Analog output channels in modules with value range -1V...+1V.
+# DIGITAL_MARKERS_IN_MODULE: Digital marker channels in modules, with values 'low' and 'high' (3.3V LVTTL).
+# SEQUENCERS_IN_MODULE:      Number of sequencers available in module.
+AO_IN_MODULE = {"QCM": 4, "QCM-RF": 2, "QRM": 2, "QRM-RF": 1, "QTM": 0, "MM": 0}
+AI_IN_MODULE = {"QCM": 0, "QCM-RF": 0, "QRM": 2, "QRM-RF": 1, "QTM": 0, "MM": 0}
+DIGITAL_MARKERS_IN_MODULE = {"QCM": 4, "QCM-RF": 2, "QRM": 4, "QRM-RF": 2, "QTM": 4, "MM": 0}
+SEQUENCERS_IN_MODULE = {"QCM": 6, "QCM-RF": 6, "QRM": 6, "QRM-RF": 6, "QTM": 8, "MM": 0}
+_get_required_qrm_qcm_attr_names: Callable[..., list[str]] | None = None
+_get_required_qtm_attr_names: Callable[..., list[str]] | None = None
+
+
+def _import_modules() -> None:
+    """Import the vendor-provided Qblox modules.
+    
+    This import is done in a function, instead of at the top-level,
+    to avoid an unnecessary dependency for programs that do not access
+    the instrument directly.
+    """
+    global qblox_instruments, Cluster, NativeCluster, ScpiCluster, ChannelMapCache, QcodesModule, DebugLevel  # noqa: PLW0603
+    global DEBUG_LEVEL, _get_required_qrm_qcm_attr_names, _get_required_qtm_attr_names  # noqa: PLW0603
+    if qblox_instruments is None:
+        import qblox_instruments
+        from qblox_instruments import Cluster
+        from qblox_instruments.native import Cluster as NativeCluster
+        from qblox_instruments.native.helpers import ChannelMapCache
+        from qblox_instruments.qcodes_drivers.module import Module as QcodesModule
+        from qblox_instruments.scpi.layers.cluster_mm_1_0 import Cluster as ScpiCluster
+        from qblox_instruments.types import DebugLevel
+
+        if tuple(map(int, qblox_instruments.__version__.split("."))) < tuple(map(int, "0.17.0".split("."))):
+            raise RuntimeError("qblox_instruments version 0.17.0 or newer is needed.")
+
+        DEBUG_LEVEL = DebugLevel.MINIMAL_CHECK
+        _get_required_qrm_qcm_attr_names = QcodesModule._get_required_parent_qrx_qcm_attr_names
+        _get_required_qtm_attr_names = QcodesModule._get_required_parent_qtm_attr_names
+
+
+class _QbloxModule:
+    """This class is for creating an 'instrument' instance which is used e.g. when creating a
+    `ChannelMapCache` instance. It should have all the necessary `._is_xxx_type(slot)` methods,
+    and module-specific set of function references.
+    """
+
+    def __init__(self, module: str, func_refs: dict[str, Callable]) -> None:
+        """Initialize a module class instance.
+
+        Parameters:
+            module:    The module name, like "QCM".
+            func_refs: The function reference dictionary for all calls.
+        """
+        self._module = module
+        setattr(self, module.replace("-", "_"), func_refs)
+        # We need to set some call specifically in the module level
+        for key, func in func_refs.items():
+            if key.startswith("is_") and hasattr(self, key):
+                setattr(self, key, getattr(self, key))
+
+            if module not in ["MM", "CMM"]:
+                if "channel_map" in key:
+                    setattr(self, key, func)
+
+    def __str__(self) -> str:
+        return self._module
+
+    def is_mm_type(self) -> bool:
+        if "MM" in str(self):
+            return True
+
+        return False
+
+    def is_qcm_type(self) -> bool:
+        """Check if a module in given slot is of type QCM.
+
+        Returns:
+            boolean: True if module is of type QCM, QCM-RF. Otherwise False.
+        """
+        if "QCM" in str(self):
+            return True
+
+        return False
+
+    def is_qrm_type(self) -> bool:
+        """Check if a module in given slot is of type QRM.
+
+        Returns:
+            boolean: True if module is of type QRM, QRM-RF. Otherwise False.
+        """
+        if "QRM" in str(self):
+            return True
+
+        return False
+
+    def is_qrc_type(self) -> bool:
+        """Check if a module in given slot is of type QRC.
+
+        Returns:
+            boolean: True if module is of type QCM. Otherwise False.
+        """
+        if "QRC" in str(self):
+            return True
+
+        return False
+
+    def is_qtm_type(self) -> bool:
+        """Check if a module in given slot is of type QTM.
+
+        Returns:
+            boolean: True if module is of type QTM. Otherwise False.
+        """
+        if "QTM" in str(self):
+            return True
+
+        return False
+
+    def is_rf_type(self) -> bool:
+        """Check if a module in given slot is of type RF.
+
+        Returns:
+            boolean: True if module is of type RF. Otherwise False.
+        """
+        if "-RF" in str(self):
+            return True
+
+        return False
+
+
+class Qblox_ClusterBase(QMI_Instrument):
+    """Base class for Qblox cluster versions based on 'native' or Qcodes-based implementations.
+    
+    Attributes:
+        DEBUG_LEVEL: The debug level to use while using Qblox. If the user wants to change the debug level in an
+                     interactive session, the cluster must be closed first, then the DEBUG_LEVEL RPC constant can
+                     be changed, and the cluster instance re-opened.
+    """
+    _rpc_constants = ["DEBUG_LEVEL"]
+
+    DEBUG_LEVEL = DEBUG_LEVEL
+
+    def __init__(
+        self,
+        context: QMI_Context,
+        name: str,
+        cluster_ip: str,
+        port: int | None = None,
+        dummy_cfg: dict | None = None,
+    ) -> None:
+        super().__init__(context, name)
+
+        _logger.info("[%s] Creating Qblox Cluster instance, with device ip:port=%s:%i", name, cluster_ip, port)
+        self.cluster_ip = cluster_ip
+        self.port = port
+        self.dummy_cfg = dummy_cfg
+        self._cluster: Any | None = None
+        self._instrument_type: str = ""
+        self._modules: dict[str, Any] = {}
+        self.cluster_funcs: dict[str, Callable] = {}
+
+        _import_modules()
+
+    @property
+    def cluster(self) -> Any:
+        """Return the underlying vendor cluster instance."""
+        assert self._cluster is not None
+        return self._cluster
+
+    @rpc_method
+    def open(self) -> None:
+        """Mark the cluster driver as open after the child class has connected and discovered modules."""
+        super().open()
+
+    @rpc_method
+    def close(self) -> None:
+        try:
+            self.cluster.stop_sequencer()
+        except RuntimeError:
+            _logger.exception("[%s] Got an error while stopping all sequencers: ", self.name)
+
+        self.cluster.clear_sequencer_flags()
+        super().close()
+
+    @rpc_method
+    def get_name(self) -> str:
+        return self._name
+
+    @rpc_method
+    def get_funcs(self) -> dict[str, Callable]:
+        """Return function references for direct cluster-level control."""
+        return self.cluster_funcs
+
+    @rpc_method
+    def get_system_state(self) -> str:
+        """Get the system state from system status. Possible states are:
+        BOOTING = "System is booting."
+        OKAY = "System is okay."
+        RESOLVED = "An error indicated by the flags occured [sic], but has been resolved."
+        ERROR = "An error indicated by the flags is occuring [sic]."
+        CRIT_ERROR = "A critical error indicated by the flags is occurring"
+
+        Returns:
+            status.name: The system status name string from SystemStatuses Enum.
+        """
+        full_status = self.cluster.get_system_status()
+        _logger.debug(f"System status: {full_status}")
+        return full_status.status.name
+
+    @rpc_method
+    def reset_cluster(self) -> None:
+        """Reset the cluster."""
+        _logger.info("Resetting the cluster.")
+        self.cluster._reset()
+
+    @rpc_method
+    def reset_module(self, slot_no: int) -> None:
+        """Reset the cluster module in the specified slot."""
+        raise NotImplementedError("This function is not implemented in the base class.")
+
+    @rpc_method
+    def get_module(self, module_type: str, slot_no: int | None = None) -> Any:
+        """Find and return requested module instance, from module type, possibly on specified slot, from cluster.
+
+        Parameters:
+            module_type: A string describing module type, e.g. "QRM", "QCM-RF", etc.
+            slot_no:     An optional expected slot position input. If `None`, first matching module is returned.
+
+        Raises:
+            ValueError: If no module with given type or in given slot is present.
+
+        Returns:
+            module: The found matching module (or cluster) instance.
+        """
+        raise NotImplementedError("This function is not implemented in the base class.")
+
+    @rpc_method
+    def get_module_func_refs(self, module_type: str, slot_no: int | None = None) -> dict[str, Callable]:
+        """Find and return requested module's function reference dictionary, for a module type,
+        possibly on specified slot, from cluster.
+
+        Parameters:
+            module_type: A string describing module type, e.g. "QRM", "QCM-RF", etc.
+            slot_no:     An optional expected slot position input. If `None`, first matching module is returned.
+
+        Returns:
+            module_func_refs: The found matching module's function references dictionary.
+        """
+        raise NotImplementedError("This function is not implemented in the base class.")
+
+    @rpc_method
+    def get_module_channels(self, module_type: str, slot_no: int | None = None, channel_type: int = 0) -> Any:
+        """Find and return requested channel configurations, all or of a specific type, on a module, on first matching
+        or specified slot, from cluster.
+
+        Always also includes full sequencer configurations -per module- in the result.
+
+        The Qblox channels are mapped by definition such that (when connecting):
+          - Output (DAC) channels in a QCM module are either 'I' or 'Q' type.
+          - Input (ADC) channels in QRM module are either 'acq_I' or 'acq_Q' type.
+          - QxM-RF modules connect_out parameter controls the configuration for two DACs, hardwired to I and Q input
+            of the RF mixer on the front end, so channels are always a mixed 'IQ' type.
+          - Marker channels are the type of digital output (DO). Typically, these are simple 'low-or-high' channels.
+          - QTM has DI/O channels, fixed per sequencer.
+        On top, the channels can be set as 'off' (disconnect) as well.
+
+        Parameters:
+            module_type:  A string describing module type, e.g. "QRM", "QCM-RF", etc.
+            slot_no:      An optional expected slot position input. If `None`, first matching module is returned.
+            channel_type: 0 - all channels (default), 1 - analog input channels (adc), 2 - analog output channels (dac),
+                          3 - marker channels, 4 - IO channels (QTM only).
+
+        Raises:
+            ValueError: If no module with given type or in given slot is present.
+
+        Returns:
+            channels:   The found matching module channel sequencer configuration(s).
+            sequencers: The simplified list of sequencer configurations of the module.
+        """
+        raise NotImplementedError("This function is not implemented in the base class.")
+
+    @rpc_method
+    def get_module_channel_map_cache(self, module_type: str, slot_no: int | None = None) -> ChannelMapCache:
+        """Get the module's cached channel map.
+
+        The 'ChannelMapCache' has several useful functions on (dis)connecting channels, clearing them, validity and
+        availability checks etc.
+
+        Parameters:
+            module_type: A string describing module type, e.g. "QRM", "QCM-RF", etc.
+            slot_no:     An optional expected slot position input. If `None`, first matching module is returned.
+        """
+        module = self.get_module(module_type, slot_no)
+        return ChannelMapCache(module, slot_no)
+
+    @rpc_method
+    def reset_trigger_monitor_count(self, trigger_index: int) -> None:
+        """Reset external trigger monitor count on given trigger.
+
+        Parameters:
+            trigger_index: The trigger number.
+
+        Raises:
+            ValueError: If the trigger index number is not valid.
+        """
+        if trigger_index not in range(1, EXT_TRIGGERS_IN_CLUSTER + 1):
+            raise ValueError(f"Invalid trigger number {trigger_index}")
+
+        self.cluster.reset_trigger_monitor_count(trigger_index)
+
+    @rpc_method
+    def get_trigger_monitor_count(self, trigger_index: int) -> int:
+        """Get external trigger monitor count on given trigger.
+
+        Parameters:
+            trigger_index: The trigger number.
+
+        Returns:
+            count: The trigger monitor count of the given trigger.
+
+        Raises:
+            ValueError: If the trigger index number is not valid.
+        """
+        if trigger_index not in range(1, EXT_TRIGGERS_IN_CLUSTER + 1):
+            raise ValueError(f"Invalid trigger number {trigger_index}")
+
+        return self.cluster.get_trigger_monitor_count(trigger_index)
+
+    @rpc_method
+    def get_trigger_monitor_latest(self) -> int:
+        """Get the latest trigger monitor count index, i.e. which trigger was last triggered.
+
+        Returns:
+            trigger_index: The trigger number.
+        """
+        return self.cluster.get_trigger_monitor_latest()
+
+
+class Qblox_NativeCluster(Qblox_ClusterBase):
+    """Class to control Qblox _native_ Cluster instrument with various devices."""
+
+    def __init__(
+        self,
+        context: QMI_Context,
+        name: str,
+        cluster_ip: str,
+        port: int | None = None,
+        dummy_cfg: dict | None = None,
+    ) -> None:
+        """Initialize Qblox cluster and collect information about the modules present.
+
+        Parameters:
+            context:    QMI context instance to create this driver in.
+            name:       Name identifier for the cluster and also for QMI context instrument name.
+            cluster_ip: The IP address string of the cluster.
+            port:       Optional IP port number if non-default port is to be used.
+            dummy_cfg:  Optional input for giving a dummy Qblox configuration dictionary. Useful for dry run testing.
+        """
+        super().__init__(context, name, cluster_ip, port, dummy_cfg)
+        self._cluster: NativeCluster | None = None
+        self._modules: dict[str, _QbloxModule] = {}
+
+    @property
+    def cluster(self) -> NativeCluster:
+        assert self._cluster is not None
+        return self._cluster
+
+    @cluster.setter
+    def cluster(self, cluster: NativeCluster) -> None:
+        assert isinstance(cluster, NativeCluster)
+        self._cluster = cluster
+
+    def _add_cluster_funcs(self) -> None:
+        """Add more functions to 'native' Cluster, as it does not have that many implemented."""
+        self.cluster_funcs["reset_trigger_monitor_count"] = partial(
+            getattr(self.cluster, "reset_trigger_monitor_count"), self.cluster
+        )
+        self.cluster_funcs["get_trigger_monitor_count"] = partial(
+            getattr(self.cluster, "get_trigger_monitor_count"), self.cluster
+        )
+        self.cluster_funcs["get_trigger_monitor_latest"] = partial(
+            getattr(self.cluster, "get_trigger_monitor_latest"), self.cluster
+        )
+        # self.cluster is the first "partial" parameter to fill in the 'self'.
+        for x in range(4):
+            self.cluster_funcs[f"_set_mrk_inv_en_{x}"] = partial(
+                getattr(self.cluster, f"_set_mrk_inv_en_{x}"), self.cluster
+            )
+            self.cluster_funcs[f"_get_mrk_inv_en_{x}"] = partial(
+                getattr(self.cluster, f"_get_mrk_inv_en_{x}"), self.cluster
+            )
+
+        # Add type handles as callables
+        for type_handle, value in self.cluster._type_handle.__dict__.items():
+            if type_handle.startswith("_is"):
+                # As 'value' gets overridden in memory for the lambda function, do like this:
+                if value:
+                    self.cluster_funcs[type_handle.lstrip("_")] = lambda: True
+                else:
+                    self.cluster_funcs[type_handle.lstrip("_")] = lambda: False
+
+    def _add_module_funcs(self, v: dict[str, Callable], module_type: str) -> None:
+        """Add more functions to 'native' Cluster, specific for a module type."""
+        # Reassign 'arm_sequencer', 'start_sequencer' and 'stop_sequencer' directly to SCPI calls
+        v["arm_sequencer"] = partial(getattr(ScpiCluster, "_arm_sequencer"), self.cluster)
+        v["start_sequencer"] = partial(getattr(ScpiCluster, "_start_sequencer"), self.cluster)
+        v["stop_sequencer"] = partial(getattr(ScpiCluster, "_stop_sequencer"), self.cluster)
+        for o in range(AO_IN_MODULE[module_type]):
+            for x in range(4):
+                v[f"_out{o}_exp{x}_config"] = partial(
+                    getattr(NativeCluster, "_set_pre_distortion_config"), self.cluster
+                )
+
+            v[f"_out{o}_fir_config"] = partial(getattr(NativeCluster, "_set_pre_distortion_config"), self.cluster)
+
+    @rpc_method
+    def open(self) -> None:
+        # Connect to the device cluster
+        self._cluster = NativeCluster(
+            identifier=self.cluster_ip, port=self.port, debug=self.DEBUG_LEVEL, dummy_cfg=self.dummy_cfg
+        )
+        self._instrument_type = self.cluster.instrument_type.value  # Should return string "MM"
+        # dict {"<slot#>": {"<instrument_type>: _QbloxModule}, containing the modules.
+        # Startup module dictionary with MM; {"<slot#>": {"<instrument_type>: _QbloxModule},
+        # to contain all available modules.
+        idn = self.cluster._get_idn()
+        _, model, _, _ = idn.split(",")
+        self._modules = {"0": _QbloxModule(model, self.cluster_funcs)}
+        for k, v in self.cluster._mod_handles.items():
+            type_handle_obj = v["type_handle"]
+            module_type = type_handle_obj.instrument_type.value
+            # Check if it is also "RF"
+            if type_handle_obj.is_rf_type:
+                module_type = module_type + "-RF"
+
+            # Add type handles as callables
+            for type_handle, value in type_handle_obj.__dict__.items():
+                if type_handle.startswith("_is"):
+                    # As 'value' gets overridden in memory for the lambda function, do like this:
+                    if value:
+                        v[type_handle.lstrip("_")] = lambda: True
+                    else:
+                        v[type_handle.lstrip("_")] = lambda: False
+
+            extra_attrs = _EXTRA_ATTRS.copy()
+            # With the new module version we need to rebrand the calls to have correct inputs
+            if module_type in ["QCM", "QRM", "QCM-RF", "QRM-RF"]:
+                num_lo = 2  # For QRM-RF it is 1, but the output is on path 1 so we need to make both, see the call...
+                num_in_channels = AI_IN_MODULE[module_type]
+                num_out_channels = AO_IN_MODULE[module_type]
+                num_markers = DIGITAL_MARKERS_IN_MODULE[module_type]
+                assert _get_required_qrm_qcm_attr_names is not None
+                extra_attrs.extend(
+                    _get_required_qrm_qcm_attr_names(num_lo, num_in_channels, num_out_channels, num_markers)
+                )
+            elif module_type in ["QTM"]:
+                assert _get_required_qtm_attr_names is not None
+                extra_attrs.extend(_get_required_qtm_attr_names())
+
+            for attr_name in extra_attrs:
+                for cluster in NativeCluster, ScpiCluster:
+                    if hasattr(cluster, attr_name):
+                        signature = str(inspect.signature(getattr(cluster, attr_name)))
+                        if "slot: int" in signature:
+                            v[attr_name] = partial(getattr(cluster, attr_name), self.cluster, int(k))
+                        else:
+                            v[attr_name] = getattr(cluster, attr_name)
+
+                        break
+
+            self._add_module_funcs(v, module_type)
+            self._modules[k] = _QbloxModule(module_type, v)
+            # Add type handles as callables
+            for type_handle, value in type_handle_obj.__dict__.items():
+                if type_handle.startswith("_is"):
+                    # As 'value' gets overridden in memory for the lambda function, do like this:
+                    if value:
+                        setattr(self._modules[k], type_handle, lambda slot: True)
+                    else:
+                        setattr(self._modules[k], type_handle, lambda slot: False)
+
+        # Add direct calls to ScpiCluster calls not implemented in 'native' Cluster
+        self._add_cluster_funcs()
+        super().open()
+
+    @rpc_method
+    def reset_module(self, slot_no: int) -> None:
+        _logger.info(f"Resetting cluster module in slot {slot_no}.")
+        self.cluster._slot_reset()
+
+    @rpc_method
+    def get_module(self, module_type: str, slot_no: int | None = None) -> NativeCluster | _QbloxModule:
+        module_type = module_type.upper()
+        if module_type == "MM" and (slot_no == 0 or slot_no is None):
+            # The Cluster management module is always at slot 0
+            return self.cluster
+
+        if module_type == "MM" and slot_no != 0:
+            raise ValueError("The Cluster management module is always at slot 0!")
+
+        # Find a module in cluster. These possibly are in numerical order, but loop anyhow.
+        # dict entry key="<slot#>", value={"<instrument_type>", func_refs": _QbloxModule}
+        for slot, module in self._modules.items():
+            # Then check if slot_no was given and matches. No need to go on if not.
+            if slot_no is not None and int(slot) != slot_no:
+                continue
+
+            if str(module) == module_type:
+                # Just double check module type before returning
+                if (
+                    module_type == "QCM"
+                    and module.is_qcm_type()
+                    or (module_type == "QRM" and module.is_qrm_type())
+                    or (module_type == "QCM-RF" and module.is_qcm_type() and module.is_rf_type())
+                    or (module_type == "QRM-RF" and module.is_qrm_type() and module.is_rf_type())
+                    or (module_type == "QTM" and module.is_qtm_type())
+                ):
+                    return module
+
+        if slot_no:
+            raise ValueError(f"Module {module_type} not found on slot position {slot_no}.")
+
+        raise ValueError(f"Module {module_type} not found.")
+
+    @rpc_method
+    def get_module_func_refs(self, module_type: str, slot_no: int | None = None) -> dict[str, Callable]:
+        module_type = module_type.upper()
+        if module_type == "MM" and (slot_no == 0 or slot_no is None):
+            # The Cluster management module is always at slot 0
+            return self.cluster_funcs
+
+        module = self.get_module(module_type, slot_no)
+        return getattr(module, module_type.replace("-", "_"))
+
+    @rpc_method
+    def get_module_channels(self, module_type: str, slot_no: int | None = None, channel_type: int = 0) -> Any:
+        module_type = module_type.upper()
+        sequencers: dict[str, Any] = {}
+        channels: dict[str, Any] = {}
+        module_func_refs = self.get_module_func_refs(module_type, slot_no)
+        # The channels definition in Qblox is done through the sequencers, and not the other way around. So, for our
+        # definition of control per channel we need to first map out the sequencers.
+        for sequencer in range(SEQUENCERS_IN_MODULE[module_type]):
+            try:
+                sequencer_config = module_func_refs["_get_sequencer_config"](sequencer)
+                if channel_type in [0, 1] and AI_IN_MODULE[module_type] > 0:
+                    # Get 'ADC' input channels if present in module
+                    sequencer_channel_map = module_func_refs["_get_sequencer_acq_channel_map"](sequencer)
+                    if "RF" in module_type.upper():
+                        for channel in [ch for map in sequencer_channel_map for ch in map]:
+                            channels[f"adc{channel}_IQ{sequencer}"] = sequencer_config["acq"]
+
+                    else:
+                        for channel in sequencer_channel_map[0]:
+                            channels[f"adc{channel}_acq_I{sequencer}"] = sequencer_config["awg"]
+
+                        for channel in sequencer_channel_map[1]:
+                            channels[f"adc{channel}_acq_Q{sequencer}"] = sequencer_config["awg"]
+
+                if channel_type in [0, 2] and AO_IN_MODULE[module_type] > 0:
+                    sequencer_channel_map = module_func_refs["_get_sequencer_channel_map"](sequencer)
+                    # The first list defines 'I' type channels, the second 'Q' type
+                    for channel in sequencer_channel_map[0]:
+                        channels[f"dac{channel}_I{sequencer}"] = sequencer_config["awg"]  # TODO: Is this always valid?
+
+                    for channel in sequencer_channel_map[1]:
+                        channels[f"dac{channel}_Q{sequencer}"] = sequencer_config["awg"]  # TODO: Is this always valid?
+
+                if channel_type in [0, 3] and DIGITAL_MARKERS_IN_MODULE[module_type] > 0:
+                    # For QCM-RF channels 0, 2 are 'daci_Is' channels and channels 1, 3 are 'dacq_Qs` channels
+                    for channel in range(DIGITAL_MARKERS_IN_MODULE[module_type]):
+                        channels[f"DO{channel}_{sequencer}"] = sequencer_config["seq_proc"]
+
+            except RuntimeError as rt_err:
+                # This should always work, so except properly if something fails
+                _logger.exception("Module %s failed to map sequencer %i." % module_type, sequencer, exc_info=rt_err)
+                raise Exception(f"Module {module_type} failed to map sequencer {sequencer}.") from rt_err
+
+            sequencers[f"sequencer{sequencer}"] = sequencer_config
+            if channel_type in [0, 4] and module_type.upper() == "QTM":
+                # QTM has IOx channels, where x is both the channel and sequencer number.
+                channels[f"IO{sequencer}"] = module_func_refs["_get_io_channel_config"](sequencer)
+
+        return channels, sequencers
+
+
+@dataclass()
+class TriggerThresholdConfig:
+    """Dataclass for holding marker channel trigger threshold parameters."""
+
+    threshold: Any
+    invert: Any
+
+
+class Qblox_QcodesCluster(Qblox_ClusterBase):
+    """Class to control Qblox Cluster instrument with various devices through QCoDeS."""
+
+    def __init__(
+        self,
+        context: QMI_Context,
+        name: str,
+        cluster_ip: str,
+        port: int | None = None,
+        dummy_cfg: dict | None = None,
+    ) -> None:
+        super().__init__(context, name, cluster_ip, port, dummy_cfg)
+        self._cluster: Cluster | None = None
+        self._modules: dict[str, dict[str, dict[str, Callable]]] = {}
+
+    @property
+    def cluster(self) -> Cluster:
+        assert self._cluster is not None
+        return self._cluster
+
+    @cluster.setter
+    def cluster(self, cluster: Cluster) -> None:
+        assert isinstance(cluster, Cluster)
+        self._cluster = cluster
+
+    def _check_error_queue(self, err: Exception | None = None) -> None:
+        """This function does not work correctly when obtained from ScpiCluster. Therefore a modified copy is used.
+        Check system error for errors. Empties and prints the complete error queue.
+
+        Parameters:
+            err:          Exception type to re-raise.
+
+        Raises:
+            Exception:    An exception was passed as input argument.
+            RuntimeError: An error occurred in system run-time.
+        """
+        if self.cluster._debug.value <= 1:
+            errors = [str(err)] if err is not None else []
+            while int(self.cluster._read("SYSTem:ERRor:COUNt?")) != 0:
+                errors.append(",".join(self.cluster._read("SYSTem:ERRor:NEXT?").split(",")[1:]))
+
+            if len(errors) > 0:
+                if err is not None:
+                    err_type = type(err)
+                else:
+                    err_type = RuntimeError
+                raise err_type("\n".join(errors)).with_traceback(sys.exc_info()[2]) from None
+
+    def _add_type_check_calls(self, module: Any) -> Any:
+        """Add `_is_xxx_type(slot)` calls into the module."""
+        if hasattr(module, "is_mm_type"):
+            setattr(module, "_is_mm_type", lambda slot: module.is_mm_type)
+
+        setattr(module, "_is_qcm_type", lambda slot: module.is_qcm_type)
+        setattr(module, "_is_qrm_type", lambda slot: module.is_qrm_type)
+        setattr(module, "_is_qrc_type", lambda slot: module.is_qrc_type)
+        setattr(module, "_is_qtm_type", lambda slot: module.is_qtm_type)
+        setattr(module, "_is_rf_type", lambda slot: module.is_rf_type)
+
+        return module
+
+    def _add_sequencer_and_acquisition_calls(self, module: Any) -> Any:
+        extra_attrs = _EXTRA_ATTRS.copy()
+        # With the new module version we need to rebrand the calls to have correct inputs
+        for attr_name in extra_attrs:
+            if hasattr(NativeCluster, attr_name):
+                try:
+                    signature = str(inspect.signature(getattr(ScpiCluster, attr_name)))
+                except AttributeError:
+                    _logger.debug(f"ScpiCluster did not have attribute {attr_name}.")
+                    continue
+
+                if "slot: int" in signature:
+                    if "channel_map" in attr_name:
+                        setattr(module, attr_name, partial(getattr(ScpiCluster, attr_name), self.cluster))
+                else:
+                    setattr(module, attr_name, getattr(ScpiCluster, attr_name))
+
+        # Reassign 'arm_sequencer', 'start_sequencer' and 'stop_sequencer' directly to SCPI write calls
+        setattr(module, "arm_sequencer", partial(getattr(ScpiCluster, "_write"), self.cluster))
+        setattr(module, "start_sequencer", partial(getattr(ScpiCluster, "_write"), self.cluster))
+        setattr(module, "stop_sequencer", partial(getattr(ScpiCluster, "_write"), self.cluster))
+
+        return module
+
+    def _make_func_refs_from_module(self, module: Any, slot: int) -> dict[str, Callable]:
+        module_func_refs = module.__dict__
+        for attr_name in ["_bin_block_write", "_write_bin", "_read", "_check_in_type"]:
+            if hasattr(ScpiCluster, attr_name):
+                partial_attr = partial(getattr(ScpiCluster, attr_name), module_func_refs)
+                module_func_refs[attr_name] = partial_attr
+
+        # TODO: Missing functions `_arm_scope_trigger` and `is_qdm_type`?
+        module_func_refs["_check_error_queue"] = self._check_error_queue
+        module_func_refs["_write"] = partial(getattr(ScpiCluster, "_write"), self.cluster)
+        module_func_refs["_read_bin"] = partial(getattr(ScpiCluster, "_read_bin"), self.cluster)
+        module_func_refs["_flush_line_end"] = partial(getattr(ScpiCluster, "_flush_line_end"), self.cluster)
+
+        module_func_refs["is_qcm_type"] = lambda: module.is_qcm_type
+        module_func_refs["is_qrm_type"] = lambda: module.is_qrm_type
+        module_func_refs["is_qrc_type"] = lambda: module.is_qrc_type
+        module_func_refs["is_qtm_type"] = lambda: module.is_qtm_type
+        module_func_refs["is_rf_type"] = lambda: module.is_rf_type
+
+        # Some extra attributes
+        extra_attrs = _EXTRA_ATTRS.copy()
+        # With the new module version we need to rebrand the calls to have correct inputs
+        for attr_name in extra_attrs:
+            if hasattr(NativeCluster, attr_name):
+                signature = str(inspect.signature(getattr(NativeCluster, attr_name)))
+                if "slot: int" in signature:
+                    module_func_refs[attr_name] = partial(getattr(NativeCluster, attr_name), self.cluster, int(slot))
+                else:
+                    module_func_refs[attr_name] = getattr(NativeCluster, attr_name)
+
+        module_func_refs["_debug"] = self.DEBUG_LEVEL
+
+        # Add remaining module functions to the function references.
+        for attr in dir(module):
+            if isinstance(getattr(module, attr), partial) and attr not in module_func_refs:
+                func = getattr(module, attr)
+                module_func_refs[attr] = func
+
+        return module_func_refs
+
+    @rpc_method
+    def open(self):
+        # Connect to the device cluster
+        self._cluster = Cluster(
+            name=self._name, identifier=self.cluster_ip, port=self.port, debug=self.DEBUG_LEVEL, dummy_cfg=self.dummy_cfg
+        )
+        self._instrument_type = self.cluster.instrument_type.value  # Should return string "MM" for cluster
+        self._modules["0"] = {self._instrument_type: self.cluster._type_handle}
+        for name, member in inspect.getmembers(self.cluster._type_handle):
+            if callable(member) and not name.startswith("__"):
+                self.cluster_funcs[name] = member
+
+        for module in self.cluster.modules:
+            if module.present():
+                slot = module.slot_idx
+                self._modules[str(slot)] = {
+                    self.cluster.modules[slot - 1].module_type.value: self.cluster.modules[slot - 1]
+                }
+
+        super().open()
+
+    @rpc_method
+    def get_module(self, module_type: str, slot_no: int | None = None) -> Any:
+        if module_type == "MM" and (slot_no == 0 or slot_no is None):
+            # The Cluster management module is always at slot 0
+            module = self._add_type_check_calls(self._modules["0"]["MM"])
+            return module
+
+        if module_type == "MM" and slot_no != 0:
+            raise ValueError("The Cluster management module is always at slot 0!")
+
+        # The modules are enumerated (from 1), so if the number and type match, return immediately
+        if slot_no is not None:
+            module = list(self._modules[str(slot_no)].values())[0]
+            module = self._add_type_check_calls(module)
+            module = self._add_sequencer_and_acquisition_calls(module)
+            return module
+
+        # Otherwise, find the module in cluster
+        for mod_dict in self._modules.values():
+            if module_type == list(mod_dict.keys())[0]:
+                module = list(mod_dict.values())[0]
+                module = self._add_type_check_calls(module)
+                module = self._add_sequencer_and_acquisition_calls(module)
+                return module
+
+        raise ValueError(f"Module {module_type} not found.")
+
+    @rpc_method
+    def get_module_func_refs(self, module_type: str, slot_no: int | None = None) -> dict[str, Callable]:
+        module_type = module_type.upper()
+        if module_type == "MM" and (slot_no == 0 or slot_no is None):
+            # The Cluster management module is always at slot 0
+            return self._add_type_check_calls(list(self._modules["0"].keys())[0])
+
+        module = self.get_module(module_type, slot_no)
+        return self._make_func_refs_from_module(module, module.slot_idx)
+
+    @rpc_method
+    def get_module_channels(self, module_type: str, slot_no: int | None = None, channel_type: int = 0) -> Any:
+        module_type = module_type.upper()
+        if module_type == "MM" or slot_no == 0:
+            raise ValueError("The Cluster management module at slot 0 doesn't have channels!")
+
+        # The modules are enumerated (from 1), so if the number and type match, return immediately
+        if slot_no is not None:
+            if module_type != list(self._modules[str(slot_no)].keys())[0]:
+                raise ValueError(f"Module {module_type} not found on slot position {slot_no}.")
+
+            module: QcodesModule = list(self._modules[str(slot_no)].values())[0]
+
+        else:
+            # Otherwise, find the module in cluster using type check
+            module_found = False
+            for slot, mod_dict in self._modules.items():
+                if module_type == list(mod_dict.keys())[0]:
+                    module = list(mod_dict.values())[0]
+                    slot_no = int(slot)
+                    module_found = True
+                    break
+
+            if not module_found:
+                raise ValueError(f"Module {module_type} not found on cluster.")
+
+        channels: dict[str, Any] = {}
+        if module_type == "QTM" and channel_type in [0, 4]:
+            io_channels = len(module.io_channels)
+            for channel in range(io_channels):
+                channels[f"IO{channel}"] = self.cluster._get_io_channel_config(slot_no, channel)
+
+            return channels, {f"sequencer{s}": seq._get_sequencer_config() for s, seq in enumerate(module.sequencers)}
+
+        try:
+            for sequencer_idx, seq_conn_point, channel_idx in module._iter_connections():
+                if channel_type in [0, 1]:
+                    if "adc" in channel_idx:
+                        ch_config = module.sequencers[sequencer_idx].parameters
+                        channels[f"{channel_idx}_{seq_conn_point}{sequencer_idx}"] = ch_config
+
+                if channel_type in [0, 2]:
+                    if "dac" in channel_idx:
+                        ch_config = module.sequencers[sequencer_idx].parameters
+                        channels[f"{channel_idx}_{seq_conn_point}{sequencer_idx}"] = ch_config
+
+                if channel_type in [0, 3]:
+                    marker_config = {
+                        "sync_en": module.sequencers[sequencer_idx].sync_en,
+                    }
+                    for trigger in range(1, EXT_TRIGGERS_IN_CLUSTER + 1):
+                        trigger_str = f"trigger{trigger}"
+                        threshold = module.sequencers[sequencer_idx].__getattr__(f"{trigger_str}_count_threshold")
+                        invert = module.sequencers[sequencer_idx].__getattr__(f"{trigger_str}_threshold_invert")
+                        marker_config.update({trigger_str: TriggerThresholdConfig(threshold=threshold, invert=invert)})
+
+                    channels[f"DO{channel_idx.lstrip('dac').lstrip('adc')}_{sequencer_idx}"] = marker_config
+
+        except RuntimeError:
+            # The module probably does not accept the SEQ#:CHAN? command. We do only the markers, if interested.
+            if channel_type in [0, 3]:
+                for sequencer_idx, sequencer in enumerate(module.sequencers):
+                    marker_config = {
+                        "sync_en": sequencer.sync_en,
+                    }
+                    for trigger in range(1, EXT_TRIGGERS_IN_CLUSTER + 1):
+                        trigger_str = f"trigger{trigger}"
+                        threshold = sequencer.__getattr__(f"{trigger_str}_count_threshold")
+                        invert = sequencer.__getattr__(f"{trigger_str}_threshold_invert")
+                        marker_config.update({trigger_str: TriggerThresholdConfig(threshold=threshold, invert=invert)})
+
+                    for channel_idx in range(4):  # We presume we end up here because the module is QTM, with 4 markers
+                        channels[f"DO{channel_idx}_{sequencer_idx}"] = marker_config
+
+        return channels, {f"sequencer{s}": seq._get_sequencer_config() for s, seq in enumerate(module.sequencers)}

--- a/qmi/instruments/qblox/cluster.py
+++ b/qmi/instruments/qblox/cluster.py
@@ -729,7 +729,7 @@ class Qblox_QcodesCluster(Qblox_ClusterBase):
         return module
 
     def _make_func_refs_from_module(self, module: Any, slot: int) -> dict[str, Callable]:
-        module_func_refs = module.__dict__
+        module_func_refs = module.__dict__.copy()
         for attr_name in ["_bin_block_write", "_write_bin", "_read", "_check_in_type"]:
             if hasattr(ScpiCluster, attr_name):
                 partial_attr = partial(getattr(ScpiCluster, attr_name), module_func_refs)

--- a/qmi/instruments/qblox/cluster.py
+++ b/qmi/instruments/qblox/cluster.py
@@ -722,9 +722,9 @@ class Qblox_QcodesCluster(Qblox_ClusterBase):
                     setattr(module, attr_name, getattr(ScpiCluster, attr_name))
 
         # Reassign 'arm_sequencer', 'start_sequencer' and 'stop_sequencer' directly to SCPI write calls
-        setattr(module, "arm_sequencer", partial(getattr(ScpiCluster, "_write"), self.cluster))
-        setattr(module, "start_sequencer", partial(getattr(ScpiCluster, "_write"), self.cluster))
-        setattr(module, "stop_sequencer", partial(getattr(ScpiCluster, "_write"), self.cluster))
+        setattr(module, "arm_sequencer", partial(getattr(ScpiCluster, "_arm_sequencer"), self.cluster))
+        setattr(module, "start_sequencer", partial(getattr(ScpiCluster, "_start_sequencer"), self.cluster))
+        setattr(module, "stop_sequencer", partial(getattr(ScpiCluster, "_stop_sequencer"), self.cluster))
 
         return module
 

--- a/qmi/instruments/qblox/cluster.py
+++ b/qmi/instruments/qblox/cluster.py
@@ -82,6 +82,7 @@ def _import_modules() -> None:
         from qblox_instruments.scpi.layers.cluster_mm_1_0 import Cluster as ScpiCluster
         from qblox_instruments.types import DebugLevel
 
+        assert qblox_instruments is not None
         if tuple(map(int, qblox_instruments.__version__.split("."))) < tuple(map(int, "0.17.0".split("."))):
             raise RuntimeError("qblox_instruments version 0.17.0 or newer is needed.")
 
@@ -228,7 +229,7 @@ class Qblox_ClusterBase(QMI_Instrument):
         try:
             self.cluster.stop_sequencer()
         except RuntimeError:
-            _logger.exception("[%s] Got an error while stopping all sequencers: ", self.name)
+            _logger.exception("[%s] Got an error while stopping all sequencers: ", self._name)
 
         self.cluster.clear_sequencer_flags()
         super().close()

--- a/tests/instruments/qblox/test_cluster.py
+++ b/tests/instruments/qblox/test_cluster.py
@@ -2,7 +2,7 @@ import copy
 import json
 import logging
 import unittest
-from unittest.mock import patch, create_autospec
+from unittest.mock import call, patch, create_autospec
 
 # from qblox_instruments.native.cluster import IpTransport
 # from qblox_instruments.qcodes_drivers.cluster import Cluster as QcodesCluster
@@ -114,17 +114,50 @@ def make_flexible_mock(return_for_getpeername):
 
 
 class TypeHandle_QbloxModule(_QbloxModule):
-    """Extended class for more complex module function"""
+    """Extended class for more complex module function handles.
+    
+    Made compatible for both Native and QCodes cluster versions.
+    """
 
     class InstrumentType:
-        def __init__(self, instr_type: str, is_rf: bool):
+        def __init__(self, instr_type: str) -> None:
             self.value = instr_type
 
-    def __init__(self, module: str, is_rf: bool):
-        self.instrument_type = self.InstrumentType(module, is_rf)
+    class ModuleType:
+        def __init__(self, module_type: str) -> None:
+            self.value = module_type
+
+    class InstrumentClass:
+        def __init__(self, instr_type: str) -> None:
+            self.value = "Cluster" if "MM" in instr_type else "Module"
+
+    def __init__(self, module: str, is_rf: bool, slot: str) -> None:
+        self.instrument_type = self.InstrumentType(module)
+        self.module_type = self.ModuleType(module)
+        self.instrument_class = self.InstrumentClass(module)
         self.is_rf_type = is_rf
+        self.slot_idx = int(slot)
         super().__init__(module, {})
 
+    def present(self) -> bool:
+        return True
+    
+    def _get_sequencer_config(self, slot: int, sequencer: int) -> dict:
+        if self.module_type.value.startswith("QCM"):
+            return QCM_SEQUENCER_CONFIG
+        if self.module_type.value.startswith("QRM"):
+            return QRM_SEQUENCER_CONFIG
+        return {}  # MM
+
+    def _get_io_channel_config(self, slot: int, sequencer: int) -> dict:
+        return IO_CHANNEL_CONFIG
+
+    def _get_sequencer_channel_map(self, slot: int, sequencer: int) -> tuple:
+        return ([0, 2], [1, 3])
+    
+    def _get_sequencer_acq_channel_map(self, slot: int, sequencer: int) -> tuple:
+        return ([0], [1])
+    
 
 class ScpiClusterStub:
     """Mock the ScpiCluster class"""
@@ -177,7 +210,7 @@ class CreateClusterTestCase(unittest.TestCase):
         for slot, module in modules.items():
             module_name = module["model"][8:]
             is_rf = module["is_rf"]
-            self._mod_handles[slot] = {"type_handle": TypeHandle_QbloxModule(module_name, is_rf)}
+            self._mod_handles[slot] = {"type_handle": TypeHandle_QbloxModule(module_name, is_rf, slot)}
 
     def tearDown(self) -> None:
         # self._read_bin_patch.stop()
@@ -203,24 +236,34 @@ class CreateClusterTestCase(unittest.TestCase):
         self.assertEqual(name, cluster._name)
         self.assertEqual("MM", cluster._instrument_type)
         cluster.close()
+        cluster_patch.assert_has_calls([
+            call(identifier=ip, port=None, debug=None, dummy_cfg=None),
+            call()._get_idn(),
+            call().stop_sequencer(),
+            call().clear_sequencer_flags()
+        ])
 
     def test_create_qcodes_cluster(self):
         # Arrange
         status = unittest.mock.Mock()
         status.status = "OKAY;NO;PROBLEMS"
-        with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch, patch(
-                "qblox_instruments.scpi.layers.cluster_mm_legacy.Cluster.get_json_description") as json_patch, patch(
-                # "qblox_instruments.scpi.cluster.Cluster.get_json_description") as json_patch, patch(
-                "qblox_instruments.scpi.scpi.Scpi.check_error_queue", autospec=True) as err_patch, patch(
-                # "qblox_instruments.scpi.cluster.Cluster.check_error_queue", autospec=True) as err_patch, patch(
-                "qblox_instruments.native.cluster.Cluster.get_system_status", return_value=status):
+        # with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch, patch(
+        #         "qblox_instruments.scpi.layers.cluster_mm_legacy.Cluster.get_json_description") as json_patch, patch(
+        #         # "qblox_instruments.scpi.cluster.Cluster.get_json_description") as json_patch, patch(
+        #         "qblox_instruments.scpi.scpi.Scpi.check_error_queue", autospec=True) as err_patch, patch(
+        #         # "qblox_instruments.scpi.cluster.Cluster.check_error_queue", autospec=True) as err_patch, patch(
+        #         "qblox_instruments.native.cluster.Cluster.get_system_status", return_value=status):
+        with patch("qmi.instruments.qblox.cluster.Cluster") as cluster_patch:
             # side_effect = ["qblox,Cluster MM,b,", "OKAY;NO;PROBLEMS"] + list(map(str, range(20)))
-            side_effect = ["qblox,Cluster MM,b,", "0", "0"] + list(map(str, range(20)))
-            read_patch.side_effect = side_effect
+            # side_effect = ["qblox,Cluster MM,b,", "0", "0"] + list(map(str, range(20)))
+            # cluster_patch.side_effect = side_effect
+            cluster_patch().instrument_type = self._mod_handles["0"]["type_handle"].instrument_type
+            cluster_patch()._type_handle = self._mod_handles["0"]["type_handle"]
+            cluster_patch().modules = [v["type_handle"] for _, v in self._mod_handles.items()]
             # json_patch.side_effect = [JSON_DESCR_MODULES]
-            json_patch.side_effect = [mock_cluster_layout, "0", "0", JSON_DESCR_MODULES]
-            err_patch.return_value = mock_cluster_layout
-            name, ip = "native", "123.45.67.89"
+            # json_patch.side_effect = [mock_cluster_layout, "0", "0", JSON_DESCR_MODULES]
+            # err_patch.return_value = mock_cluster_layout
+            name, ip = "qcoodes", "123.45.67.89"
             # Act
             cluster = Qblox_QcodesCluster(self._ctx, name, ip)
             cluster.open()
@@ -229,36 +272,73 @@ class CreateClusterTestCase(unittest.TestCase):
         self.assertEqual(name, cluster._name)
         self.assertEqual("MM", cluster._instrument_type)
         cluster.close()
+        cluster_patch.assert_has_calls([
+            call(name=name, identifier=ip, port=None, debug=None, dummy_cfg=None),
+            call().stop_sequencer(),
+            call().clear_sequencer_flags()
+        ])
 
 
 class NativeClusterTestCase(unittest.TestCase):
     """Test native cluster instance methods."""
+    EXTRA_ATTRS = ["_get_sequencer_config"]
 
     def setUp(self) -> None:
-        self._read_bin_patch = patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
-        self._read_bin_patch.start()
-        with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as self.read_patch:
+        _mod_handles = {}
+        for slot, module in modules.items():
+            module_name = module["model"][8:]
+            is_rf = module["is_rf"]
+            _mod_handles[slot] = {
+                "type_handle": TypeHandle_QbloxModule(module_name, is_rf, slot),
+                "_get_sequencer_channel_map": TypeHandle_QbloxModule._get_sequencer_channel_map
+            }
+
+        self._qblox_instruments_patch = patch("qmi.instruments.qblox.cluster.qblox_instruments", unittest.mock.Mock())
+        self._qblox_instruments_patch.start()
+        self.addCleanup(self._qblox_instruments_patch.stop)
+        # self._read_bin_patch = patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
+        # self._read_bin_patch.start()
+        # with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as self.read_patch:
+        self._scpi_cluster_patch = patch("qmi.instruments.qblox.cluster.ScpiCluster", ScpiClusterStub)
+        self._scpi_cluster_patch.start()
+        self.addCleanup(self._scpi_cluster_patch.stop)
+        self._attr_names_patch = patch("qmi.instruments.qblox.cluster._get_required_qrm_qcm_attr_names", return_value=self.EXTRA_ATTRS)
+        self._qtm_attr_names_patch = patch("qmi.instruments.qblox.cluster._get_required_qtm_attr_names", return_value=self.EXTRA_ATTRS)
+        self._attr_names_patch.start()
+        self._qtm_attr_names_patch.start()
+        self.addCleanup(self._attr_names_patch.stop)
+        self.addCleanup(self._qtm_attr_names_patch.stop)
+        with patch("qmi.instruments.qblox.cluster.NativeCluster") as cluster_patch:
+            cluster_patch._get_sequencer_config = TypeHandle_QbloxModule._get_sequencer_config
+            cluster_patch._get_io_channel_config = TypeHandle_QbloxModule._get_io_channel_config
+            cluster_patch._get_sequencer_channel_map = TypeHandle_QbloxModule._get_sequencer_channel_map
+            cluster_patch._get_sequencer_acq_channel_map = TypeHandle_QbloxModule._get_sequencer_acq_channel_map
             side_effect = ["qblox,Cluster_MM,b," + BUILD_INFO] * 2
-            side_effect.extend(["0", "0"])
-            self.read_patch.side_effect = side_effect
-            setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
-            self._read_bin_patch.target._read_bin.side_effect = (
-                [JSON_DESCR_MODULES]
-                + [json.dumps(QCM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0, 2], [1, 3]]"] * 12
-                + [json.dumps(QRM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0], [1]]", b"[[0], [1]]"] * 12
-                + [json.dumps(QTM_SEQUENCER_CONFIG).encode("utf-8"), json.dumps(IO_CHANNEL_CONFIG).encode("utf-8")] * 8
-            )
+            cluster_patch().instrument_type = _mod_handles["0"]["type_handle"].instrument_type
+            cluster_patch().instrument_class = _mod_handles["0"]["type_handle"].instrument_class
+            cluster_patch()._get_idn = unittest.mock.Mock(side_effect=side_effect)
+            cluster_patch()._mod_handles = _mod_handles
+            cluster_patch()._type_handle = _mod_handles["0"]["type_handle"]
+            # side_effect.extend(["0", "0"])
+            # self.read_patch.side_effect = side_effect
+            # setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
+            # self._read_bin_patch.target._read_bin.side_effect = (
+            #     [JSON_DESCR_MODULES]
+            #     + [json.dumps(QCM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0, 2], [1, 3]]"] * 12
+            #     + [json.dumps(QRM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0], [1]]", b"[[0], [1]]"] * 12
+            #     + [json.dumps(QTM_SEQUENCER_CONFIG).encode("utf-8"), json.dumps(IO_CHANNEL_CONFIG).encode("utf-8")] * 8
+            # )
             name, ip = "native", "123.45.67.89"
             qmi.instruments.qblox.cluster.DEBUG_LEVEL = 2  # Set to 2 to avoid useless error checks
-            _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
-            with patch("qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport) as self._scpi_transport:
+            # _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
+            # with patch("qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport) as self._scpi_transport:
             # with patch("qblox_instruments.native.cluster.IpTransport", spec=IpTransport) as self._scpi_transport:
-                _ctx = QMI_Context("cluster_test")
-                self.cluster = Qblox_NativeCluster(_ctx, name, ip)
-                self.cluster.open()
+            _ctx = QMI_Context("cluster_test")
+            self.cluster = Qblox_NativeCluster(_ctx, name, ip)
+            self.cluster.open()
 
     def tearDown(self) -> None:
-        self._read_bin_patch.stop()
+        # self._read_bin_patch.stop()
         self.cluster.close()
 
     def test_get_module(self):

--- a/tests/instruments/qblox/test_cluster.py
+++ b/tests/instruments/qblox/test_cluster.py
@@ -270,6 +270,33 @@ class CreateClusterTestCase(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             cluster.get_module_channels("QCM")
 
+    def test_test_helpers_cover_default_paths(self):
+        mm_handle = TypeHandle_QbloxModule("MM", False, 0)
+        qcm_handle = TypeHandle_QbloxModule("QCM", False, 1)
+        qrm_handle = TypeHandle_QbloxModule("QRM", False, 3)
+
+        self.assertTrue(mm_handle.present())
+        self.assertEqual({}, mm_handle._get_sequencer_config(0, 0))
+        self.assertIs(qcm_handle._get_io_channel_config(), IO_CHANNEL_CONFIG)
+        self.assertIs(qcm_handle._get_sequencer_config(1, 0), QCM_SEQUENCER_CONFIG)
+        self.assertIs(qrm_handle._get_sequencer_config(3, 0), QRM_SEQUENCER_CONFIG)
+        self.assertEqual(([0, 2], [1, 3]), qcm_handle._get_sequencer_channel_map(1, 0))
+        self.assertEqual(([0], [1]), qrm_handle._get_sequencer_channel_map(3, 0))
+        self.assertEqual(([0], [1]), qcm_handle._get_sequencer_acq_channel_map(1, 0))
+
+        scpi_stub = ScpiClusterStub()
+        self.assertIsNone(scpi_stub._arm_sequencer())
+        self.assertIsNone(scpi_stub._start_sequencer())
+        self.assertIsNone(scpi_stub._stop_sequencer())
+        self.assertIsNone(scpi_stub._write("cmd"))
+        self.assertIsNone(scpi_stub._read_bin())
+        self.assertIsNone(scpi_stub._flush_line_end())
+
+        module = unittest.mock.Mock()
+        returned_module = self._add_is_functions_to_module(module, "QCM-RF")
+        self.assertIs(returned_module, module)
+        self.assertTrue(hasattr(module, "is_qcm_type"))
+
 
 class NativeClusterTestCase(unittest.TestCase):
     """Test native cluster instance methods."""

--- a/tests/instruments/qblox/test_cluster.py
+++ b/tests/instruments/qblox/test_cluster.py
@@ -2,12 +2,7 @@ import copy
 import json
 import logging
 import unittest
-from unittest.mock import call, patch, create_autospec
-
-# from qblox_instruments.native.cluster import IpTransport
-# from qblox_instruments.qcodes_drivers.cluster import Cluster as QcodesCluster
-# from qblox_instruments.qcodes_drivers.module import Module
-# from qblox_instruments.types import TypeHandle, InstrumentType
+from unittest.mock import call, patch
 
 import qmi.instruments.qblox.cluster
 from qmi.instruments.qblox import (
@@ -101,18 +96,6 @@ IO_CHANNEL_CONFIG = {
 }
 
 
-def make_flexible_mock(return_for_getpeername):
-    class FlexibleMock(unittest.mock.MagicMock):
-        def __getattr__(self, name):
-            if name == "getpeername":
-                m = unittest.mock.MagicMock()
-                m.return_value = return_for_getpeername
-                return m
-            return super().__getattr__(name)
-
-    return FlexibleMock("qblox_instruments.native.cluster.IpTransport")
-
-
 class TypeHandle_QbloxModule(_QbloxModule):
     """Extended class for more complex module function handles.
     
@@ -143,16 +126,21 @@ class TypeHandle_QbloxModule(_QbloxModule):
         return True
     
     def _get_sequencer_config(self, slot: int, sequencer: int) -> dict:
-        if self.module_type.value.startswith("QCM"):
+        if "QCM" in modules[str(slot)]["model"]:
             return QCM_SEQUENCER_CONFIG
-        if self.module_type.value.startswith("QRM"):
+        if "QRM" in modules[str(slot)]["model"]:
             return QRM_SEQUENCER_CONFIG
+        if "QTM" in modules[str(slot)]["model"]:
+            return QTM_SEQUENCER_CONFIG
         return {}  # MM
 
-    def _get_io_channel_config(self, slot: int, sequencer: int) -> dict:
+    def _get_io_channel_config(self) -> dict:
         return IO_CHANNEL_CONFIG
 
     def _get_sequencer_channel_map(self, slot: int, sequencer: int) -> tuple:
+        if "QRM" in modules[str(slot)]["model"]:
+            return ([0], [1])
+        
         return ([0, 2], [1, 3])
     
     def _get_sequencer_acq_channel_map(self, slot: int, sequencer: int) -> tuple:
@@ -165,6 +153,9 @@ class ScpiClusterStub:
     def _arm_sequencer(self): ...
     def _start_sequencer(self): ...
     def _stop_sequencer(self): ...
+    def _write(self, arg): ...
+    def _read_bin(self): ...
+    def _flush_line_end(self): ...
 
 
 class CreateClusterTestCase(unittest.TestCase):
@@ -174,16 +165,6 @@ class CreateClusterTestCase(unittest.TestCase):
         types = ["mm", "qcm", "qrm", "qtm", "rf"]
         for mod_type in types:
             setattr(mod, f"is_{mod_type}_type", lambda: mod_type.upper() in mod_e)
-        #     if "QCM" in mod_e and not "RF" in mod_e:
-        #         func_refs.QCM[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
-        #     elif "QRM" in mod_e and not "RF" in mod_e:
-        #         func_refs.QRM[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
-        #     elif "QTM" in mod_e:
-        #         func_refs.QTM[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
-        #     elif "QCM" in mod_e and "RF" in mod_e:
-        #         func_refs.QCM_RF[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
-        #     elif "QRM" in mod_e and "RF" in mod_e:
-        #         func_refs.QRM_RF[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
 
         return mod
 
@@ -192,11 +173,6 @@ class CreateClusterTestCase(unittest.TestCase):
         self._qblox_instruments_patch = patch("qmi.instruments.qblox.cluster.qblox_instruments", unittest.mock.Mock())
         self._qblox_instruments_patch.start()
         self.addCleanup(self._qblox_instruments_patch.stop)
-        # _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
-        # self._scpi_transport = patch("qmi.instruments.qblox.cluster.qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport)
-        # self._read_bin_patch = patch("qmi.instruments.qblox.cluster.qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
-        # self._scpi_transport.start()
-        # self._read_bin_patch.start()
         self._scpi_cluster_patch = patch("qmi.instruments.qblox.cluster.ScpiCluster", ScpiClusterStub)
         self._scpi_cluster_patch.start()
         self.addCleanup(self._scpi_cluster_patch.stop)
@@ -212,23 +188,13 @@ class CreateClusterTestCase(unittest.TestCase):
             is_rf = module["is_rf"]
             self._mod_handles[slot] = {"type_handle": TypeHandle_QbloxModule(module_name, is_rf, slot)}
 
-    def tearDown(self) -> None:
-        # self._read_bin_patch.stop()
-        # self._scpi_transport.stop()
-        pass
-
     def test_create_native_cluster(self):
-        # with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch:
         with patch("qmi.instruments.qblox.cluster.NativeCluster") as cluster_patch:
             side_effect = ["qblox,Cluster_MM,b," + BUILD_INFO, "0"]
             cluster_patch().instrument_type = self._mod_handles["0"]["type_handle"].instrument_type
             cluster_patch()._get_idn = unittest.mock.Mock(side_effect=side_effect)
             cluster_patch()._mod_handles = self._mod_handles
             cluster_patch()._type_handle = self._mod_handles["0"]["type_handle"]
-            # side_effect.extend(["0"] * 2 + ["a,Cluster_MM,b," + BUILD_INFO] + ["0"] * 2)
-            # read_patch.side_effect = side_effect
-            # setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
-            # self._read_bin_patch.target._read_bin.side_effect = [MOCK_CLUSTER_LAYOUT] + 2 * [b"0"]
             name, ip = "native", "123.45.67.89"
             cluster = Qblox_NativeCluster(self._ctx, name, ip)
             cluster.open()
@@ -247,22 +213,10 @@ class CreateClusterTestCase(unittest.TestCase):
         # Arrange
         status = unittest.mock.Mock()
         status.status = "OKAY;NO;PROBLEMS"
-        # with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch, patch(
-        #         "qblox_instruments.scpi.layers.cluster_mm_legacy.Cluster.get_json_description") as json_patch, patch(
-        #         # "qblox_instruments.scpi.cluster.Cluster.get_json_description") as json_patch, patch(
-        #         "qblox_instruments.scpi.scpi.Scpi.check_error_queue", autospec=True) as err_patch, patch(
-        #         # "qblox_instruments.scpi.cluster.Cluster.check_error_queue", autospec=True) as err_patch, patch(
-        #         "qblox_instruments.native.cluster.Cluster.get_system_status", return_value=status):
         with patch("qmi.instruments.qblox.cluster.Cluster") as cluster_patch:
-            # side_effect = ["qblox,Cluster MM,b,", "OKAY;NO;PROBLEMS"] + list(map(str, range(20)))
-            # side_effect = ["qblox,Cluster MM,b,", "0", "0"] + list(map(str, range(20)))
-            # cluster_patch.side_effect = side_effect
             cluster_patch().instrument_type = self._mod_handles["0"]["type_handle"].instrument_type
             cluster_patch()._type_handle = self._mod_handles["0"]["type_handle"]
             cluster_patch().modules = [v["type_handle"] for _, v in self._mod_handles.items()]
-            # json_patch.side_effect = [JSON_DESCR_MODULES]
-            # json_patch.side_effect = [mock_cluster_layout, "0", "0", JSON_DESCR_MODULES]
-            # err_patch.return_value = mock_cluster_layout
             name, ip = "qcoodes", "123.45.67.89"
             # Act
             cluster = Qblox_QcodesCluster(self._ctx, name, ip)
@@ -290,15 +244,13 @@ class NativeClusterTestCase(unittest.TestCase):
             is_rf = module["is_rf"]
             _mod_handles[slot] = {
                 "type_handle": TypeHandle_QbloxModule(module_name, is_rf, slot),
-                "_get_sequencer_channel_map": TypeHandle_QbloxModule._get_sequencer_channel_map
+                "_get_sequencer_channel_map": TypeHandle_QbloxModule._get_sequencer_channel_map,
+                "_get_io_channel_config": TypeHandle_QbloxModule._get_io_channel_config
             }
 
         self._qblox_instruments_patch = patch("qmi.instruments.qblox.cluster.qblox_instruments", unittest.mock.Mock())
         self._qblox_instruments_patch.start()
         self.addCleanup(self._qblox_instruments_patch.stop)
-        # self._read_bin_patch = patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
-        # self._read_bin_patch.start()
-        # with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as self.read_patch:
         self._scpi_cluster_patch = patch("qmi.instruments.qblox.cluster.ScpiCluster", ScpiClusterStub)
         self._scpi_cluster_patch.start()
         self.addCleanup(self._scpi_cluster_patch.stop)
@@ -319,26 +271,13 @@ class NativeClusterTestCase(unittest.TestCase):
             cluster_patch()._get_idn = unittest.mock.Mock(side_effect=side_effect)
             cluster_patch()._mod_handles = _mod_handles
             cluster_patch()._type_handle = _mod_handles["0"]["type_handle"]
-            # side_effect.extend(["0", "0"])
-            # self.read_patch.side_effect = side_effect
-            # setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
-            # self._read_bin_patch.target._read_bin.side_effect = (
-            #     [JSON_DESCR_MODULES]
-            #     + [json.dumps(QCM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0, 2], [1, 3]]"] * 12
-            #     + [json.dumps(QRM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0], [1]]", b"[[0], [1]]"] * 12
-            #     + [json.dumps(QTM_SEQUENCER_CONFIG).encode("utf-8"), json.dumps(IO_CHANNEL_CONFIG).encode("utf-8")] * 8
-            # )
             name, ip = "native", "123.45.67.89"
             qmi.instruments.qblox.cluster.DEBUG_LEVEL = 2  # Set to 2 to avoid useless error checks
-            # _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
-            # with patch("qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport) as self._scpi_transport:
-            # with patch("qblox_instruments.native.cluster.IpTransport", spec=IpTransport) as self._scpi_transport:
             _ctx = QMI_Context("cluster_test")
             self.cluster = Qblox_NativeCluster(_ctx, name, ip)
             self.cluster.open()
 
     def tearDown(self) -> None:
-        # self._read_bin_patch.stop()
         self.cluster.close()
 
     def test_get_module(self):
@@ -412,12 +351,6 @@ class ValString(str):
         return str(self)
 
 
-# class TypeHandleWithSetter(TypeHandle):
-# 
-#     def __setattr__(self, par, val):
-#         self.__dict__[f"{par}"] = val
-
-
 class QcodesClusterTestCase(unittest.TestCase):
     """Test SCPI cluster instance methods."""
 
@@ -429,70 +362,45 @@ class QcodesClusterTestCase(unittest.TestCase):
         return mod
 
     def setUp(self) -> None:
-        _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
-        self._scpi_transport = patch("qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport)
-        self._scpi_transport.start()
-        self._read_bin_patch = patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
-        self._read_bin_patch.start()
-        setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
-        self._read_bin_patch.target._read_bin.side_effect = (
-            [MOCK_CLUSTER_LAYOUT] + [JSON_DESCR_MODULES]
-            + [json.dumps(QCM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0, 2], [1, 3]]"] * 12
-            + [json.dumps(QRM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0], [1]]", b"[[0], [1]]"] * 12
-            + [json.dumps(QTM_SEQUENCER_CONFIG).encode("utf-8"), json.dumps(IO_CHANNEL_CONFIG).encode("utf-8")] * 8
-        )
-        with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch, patch(
-                "qblox_instruments.scpi.layers.cluster_mm_1_0.Cluster.get_json_description") as json_patch, patch(
-                "qblox_instruments.scpi.layers.cluster_mm_1_0.Cluster.check_error_queue", autospec=True
-        ):
-            side_effect = ["a,Cluster MM,b,", "OKAY;NO;PROBLEMS"] + list(map(str, range(20)))
-            read_patch.side_effect = side_effect
-            json_patch.return_value = mock_cluster_layout  # , b"0", b"0", JSON_DESCR_MODULES]
+        self._qblox_instruments_patch = patch("qmi.instruments.qblox.cluster.qblox_instruments", unittest.mock.Mock())
+        self._qblox_instruments_patch.start()
+        self.addCleanup(self._qblox_instruments_patch.stop)
+        self._scpi_cluster_patch = patch("qmi.instruments.qblox.cluster.ScpiCluster", ScpiClusterStub)
+        self._scpi_cluster_patch.start()
+        self.addCleanup(self._scpi_cluster_patch.stop)
+        with patch("qmi.instruments.qblox.cluster.Cluster") as cluster_patch:
             name, ip = "skippy", "123.45.67.89"
             qmi.instruments.qblox.cluster.DEBUG_LEVEL = 2  # Set to 2 to avoid useless error checks
             _ctx = QMI_Context("cluster_test")
-            with patch("qblox_instruments.native.cluster.Cluster._present_at_init") as present_patch, patch(
-                "qmi.instruments.qblox.cluster.Cluster") as qcodes_patch:
-                modules = ["QCM", "QCM-RF", "QRM", "QRM-RF", "QTM"]
-                # module_handles = [
-                    # TypeHandle(f"CLUSTER_{module}") for module in modules
-                # ]
-                module_handles = [
-                    _QbloxModule(f"CLUSTER_{module}") for module in modules
-                ]
-                # present_patch.side_effect = [module_handles + [TypeHandle("CLUSTER_QDM")] * 14] * 5
-                present_patch.side_effect = [module_handles + [_QbloxModule("CLUSTER_QDM", {})] * 14] * 5
-                # attr_patch.return_value = [
-                #     "is_qrm_type", "is_qtm_type", "is_rf_type", "is_qrc_type", "is_qcm_type"
-                # ]
-                # retval = create_autospec(QcodesCluster, instance=False)
-                # retval.instrument_type = InstrumentType("MM")
-                retval = unittest.mock.MagicMock()
-                retval.instrument_type = _QbloxModule("MM", {})
-                # retval._type_handle = self._add_is_functions_to_module(TypeHandleWithSetter("Cluster_MM"), "MM")
-                retval._type_handle = self._add_is_functions_to_module(unittest.mock.MagicMock("Cluster_MM"), "MM")
-                retval.modules = []
-                for e, mod in enumerate(modules):
-                    # inst_mod = create_autospec(Module)(None, modules[e], e + 1)
-                    inst_mod = create_autospec(_QbloxModule)(modules[e], {})
-                    inst_mod.present = lambda : True
-                    inst_mod.module_type = ValString(modules[e])
-                    inst_mod.slot_idx = e + 1
-                    inst_mod.name = mod
-                    inst_mod.is_mm_type = lambda : False
-                    inst_mod.is_qcm_type = lambda : mod == "QCM"
-                    inst_mod.is_qrm_type = lambda : mod == "QRM"
-                    inst_mod.is_qtm_type = lambda : mod == "QTM"
-                    inst_mod.is_rf_type = lambda : "RF" in mod
-                    retval.modules.append(inst_mod)
+            modules = ["QCM", "QCM-RF", "QRM", "QRM-RF", "QTM"]
+            retval = unittest.mock.MagicMock()
+            retval.instrument_type = TypeHandle_QbloxModule("MM", False, 0).instrument_type
+            retval._type_handle = self._add_is_functions_to_module(unittest.mock.MagicMock("Cluster_MM"), "MM")
+            retval.modules = []
+            for e, mod in enumerate(modules):
+                is_rf = True if "RF" in mod else False
+                inst_mod = TypeHandle_QbloxModule(mod, is_rf, e)
+                inst_mod.present = lambda : True
+                inst_mod.module_type = ValString(modules[e])
+                inst_mod.slot_idx = e + 1
+                inst_mod.name = mod
+                # inst_mod.is_mm_type = lambda : False
+                # inst_mod.is_qcm_type = lambda : mod == "QCM"
+                # inst_mod.is_qrm_type = lambda : mod == "QRM"
+                # inst_mod.is_qtm_type = lambda : mod == "QTM"
+                # inst_mod.is_rf_type = lambda : "RF" in mod
+                inst_mod.is_mm_type = False
+                inst_mod.is_qcm_type = "QCM" in mod
+                inst_mod.is_qrm_type = "QRM" in mod
+                inst_mod.is_qtm_type = mod == "QTM"
+                # inst_mod.is_rf_type = "RF" in mod
+                retval.modules.append(inst_mod)
 
-                qcodes_patch.return_value = retval
-                self.cluster = Qblox_QcodesCluster(_ctx, name, ip)
-                self.cluster.open()
+            cluster_patch.return_value = retval
+            self.cluster = Qblox_QcodesCluster(_ctx, name, ip)
+            self.cluster.open()
 
     def tearDown(self) -> None:
-        self._read_bin_patch.stop()
-        self._scpi_transport.stop()
         self.cluster.close()
 
     def test_get_module(self):
@@ -504,69 +412,69 @@ class QcodesClusterTestCase(unittest.TestCase):
         qcm = self.cluster.get_module("QCM")
         self.assertEqual("QCM", qcm.name)
         self.assertTrue(qcm.is_qcm_type)
-        # self.assertFalse(qcm.is_qrm_type)
-        # self.assertFalse(qcm.is_qtm_type)
-        # self.assertFalse(qcm.is_rf_type)
+        self.assertFalse(qcm.is_qrm_type)
+        self.assertFalse(qcm.is_qtm_type)
+        self.assertFalse(qcm.is_rf_type)
 
         qcm_rf = self.cluster.get_module("QCM-RF")
         self.assertEqual("QCM-RF", qcm_rf.name)
         self.assertTrue(qcm_rf.is_qcm_type)
-        # self.assertFalse(qcm_rf.is_qrm_type)
-        # self.assertFalse(qcm_rf.is_qtm_type)
+        self.assertFalse(qcm_rf.is_qrm_type)
+        self.assertFalse(qcm_rf.is_qtm_type)
         self.assertTrue(qcm_rf.is_rf_type)
 
         qrm = self.cluster.get_module("QRM")
         self.assertEqual("QRM", qrm.name)
-        # self.assertFalse(qrm.is_qcm_type)
+        self.assertFalse(qrm.is_qcm_type)
         self.assertTrue(qrm.is_qrm_type)
-        # self.assertFalse(qrm.is_qtm_type)
-        # self.assertFalse(qrm.is_rf_type)
+        self.assertFalse(qrm.is_qtm_type)
+        self.assertFalse(qrm.is_rf_type)
 
         qrm_rf = self.cluster.get_module("QRM-RF")
         self.assertEqual("QRM-RF", qrm_rf.name)
-        # self.assertFalse(qrm_rf.is_qcm_type)
+        self.assertFalse(qrm_rf.is_qcm_type)
         self.assertTrue(qrm_rf.is_qrm_type)
-        # self.assertFalse(qrm_rf.is_qtm_type)
+        self.assertFalse(qrm_rf.is_qtm_type)
         self.assertTrue(qrm_rf.is_rf_type)
 
         qtm = self.cluster.get_module("QTM")
         self.assertEqual("QTM", qtm.name)
-        # self.assertFalse(qtm.is_qcm_type)
-        # self.assertFalse(qtm.is_qrm_type)
+        self.assertFalse(qtm.is_qcm_type)
+        self.assertFalse(qtm.is_qrm_type)
         self.assertTrue(qtm.is_qtm_type)
-        # self.assertFalse(qtm.is_rf_type)
+        self.assertFalse(qtm.is_rf_type)
 
     def test_get_module_func_refs(self):
         # TODO: These tests do not run properly. Try to fix!
         qcm = self.cluster.get_module_func_refs("QCM")
         self.assertTrue(qcm["is_qcm_type"]())
-        # self.assertFalse(qcm["is_qrm_type"]())
-        # self.assertFalse(qcm["is_qtm_type"]())
-        # self.assertFalse(qcm["is_rf_type"]())
+        self.assertFalse(qcm["is_qrm_type"]())
+        self.assertFalse(qcm["is_qtm_type"]())
+        self.assertFalse(qcm["is_rf_type"]())
 
         qcm_rf = self.cluster.get_module_func_refs("QCM-RF")
         self.assertTrue(qcm_rf["is_qcm_type"]())
-        # self.assertFalse(qcm_rf["is_qrm_type"]())
-        # self.assertFalse(qcm_rf["is_qtm_type"]())
+        self.assertFalse(qcm_rf["is_qrm_type"]())
+        self.assertFalse(qcm_rf["is_qtm_type"]())
         self.assertTrue(qcm_rf["is_rf_type"]())
 
         qrm = self.cluster.get_module_func_refs("QRM")
-        # self.assertFalse(qrm["is_qcm_type"]())
+        self.assertFalse(qrm["is_qcm_type"]())
         self.assertTrue(qrm["is_qrm_type"]())
-        # self.assertFalse(qrm["is_qtm_type"]())
-        # self.assertFalse(qrm["is_rf_type"]())
+        self.assertFalse(qrm["is_qtm_type"]())
+        self.assertFalse(qrm["is_rf_type"]())
 
         qrm_rf = self.cluster.get_module_func_refs("QRM-RF")
-        # self.assertFalse(qrm_rf["is_qcm_type"]())
+        self.assertFalse(qrm_rf["is_qcm_type"]())
         self.assertTrue(qrm_rf["is_qrm_type"]())
-        # self.assertFalse(qrm_rf["is_qtm_type"]())
+        self.assertFalse(qrm_rf["is_qtm_type"]())
         self.assertTrue(qrm_rf["is_rf_type"]())
 
         qtm = self.cluster.get_module_func_refs("QTM")
-        # self.assertFalse(qtm["is_qcm_type"]())
-        # self.assertFalse(qtm["is_qrm_type"]())
+        self.assertFalse(qtm["is_qcm_type"]())
+        self.assertFalse(qtm["is_qrm_type"]())
         self.assertTrue(qtm["is_qtm_type"]())
-        # self.assertFalse(qtm["is_rf_type"]())
+        self.assertFalse(qtm["is_rf_type"]())
 
     def test_get_channels(self):
         """Test getting all channels and sequencers out from the modules"""
@@ -583,9 +491,6 @@ class QcodesClusterTestCase(unittest.TestCase):
                     + DIGITAL_MARKERS_IN_MODULE[module]
                     + AI_IN_MODULE[module]
                 ) * SEQUENCERS_IN_MODULE[module]
-            # if "RF" in module:  # The RF modules are created using the regular non-RF channel map, giving double AIO
-            #     expected_channels += 2 * SEQUENCERS_IN_MODULE[module]
-            #
             if module == "QTM":  # The QTM module has 8 "generic" IO channels in output
                 expected_channels = SEQUENCERS_IN_MODULE[module]
 
@@ -595,7 +500,7 @@ class QcodesClusterTestCase(unittest.TestCase):
             module_mock.io_channels = [f"IO{i}" for i in range(num_seq)] if module == "QTM" else []
             sequencers_mock = unittest.mock.Mock()
             sequencers_mock._get_sequencer_config = unittest.mock.Mock(return_value=SequencerObject)
-            for s in range(num_seq):
+            for _ in range(num_seq):
                 module_mock.sequencers.append(sequencers_mock)
 
             side_effects = []

--- a/tests/instruments/qblox/test_cluster.py
+++ b/tests/instruments/qblox/test_cluster.py
@@ -209,7 +209,7 @@ class CreateClusterTestCase(unittest.TestCase):
             call()._get_idn(),
             call().stop_sequencer(),
             call().clear_sequencer_flags()
-        ])
+        ], any_order=True)
 
     def test_create_qcodes_cluster(self):
         # Arrange

--- a/tests/instruments/qblox/test_cluster.py
+++ b/tests/instruments/qblox/test_cluster.py
@@ -1,0 +1,548 @@
+import copy
+import json
+import logging
+import unittest
+from unittest.mock import patch, create_autospec
+
+# from qblox_instruments.native.cluster import IpTransport
+# from qblox_instruments.qcodes_drivers.cluster import Cluster as QcodesCluster
+# from qblox_instruments.qcodes_drivers.module import Module
+# from qblox_instruments.types import TypeHandle, InstrumentType
+
+import qmi.instruments.qblox.cluster
+from qmi.instruments.qblox import (
+    Qblox_NativeCluster, Qblox_QcodesCluster, SEQUENCERS_IN_MODULE, AI_IN_MODULE, AO_IN_MODULE, DIGITAL_MARKERS_IN_MODULE
+)
+from qmi.instruments.qblox.cluster import _QbloxModule
+from tests.patcher import PatcherQmiContext as QMI_Context
+
+# Suppress logging
+logging.getLogger("resolver").setLevel(logging.CRITICAL)
+logging.getLogger("lib.instrument_maker").setLevel(logging.CRITICAL)
+
+qmi.instruments.qblox.cluster.DEBUG_LEVEL = 1
+BUILD_INFO = (
+    "fwVersion=0.6.0 fwBuild=10/07/2023-22:06:19 fwHash=0x586B0909 fwDirty=0 "
+    + "kmodVersion=0.6.0 kmodBuild=10/07/2023-22:06:19 kmodHash=0x586B0909 kmodDirty=0 "
+    + "swVersion=0.6.0 swBuild=10/07/2023-22:06:19 swHash=0x586B0909 swDirty=0 cfgManVersion=0.3.0 "
+    + "cfgManBuild=10/07/2023-22:06:19 cfgManHash=0x586B0909 cfgManDirty=0"
+)
+mock_cluster_layout = {
+    "MM 0": {"IDN": "a,Cluster MM,b," + BUILD_INFO},
+    "QCM 1": {"IDN": "a,Cluster QCM,b," + BUILD_INFO},
+    "QCM-RF 2": {"IDN": "a,Cluster QCM,b," + BUILD_INFO},
+    "QRM 3": {"IDN": "a,Cluster QRM,b," + BUILD_INFO},
+    "QRM-RF 4": {"IDN": "a,Cluster QRM,b," + BUILD_INFO},
+    "QTM 5": {"IDN": "a,Cluster QTM,b," + BUILD_INFO},
+}
+
+MOCK_CLUSTER_LAYOUT = json.dumps(mock_cluster_layout).encode("utf-8")
+modules = {
+        "0": {"model": "CLUSTER MM", "is_rf": False},
+        "1": {"model": "CLUSTER QCM", "is_rf": False},
+        "2": {"model": "CLUSTER QCM", "is_rf": True},
+        "3": {"model": "CLUSTER QRM", "is_rf": False},
+        "4": {"model": "CLUSTER QRM", "is_rf": True},
+        "5": {"model": "CLUSTER QTM", "is_rf": False},
+    }
+JSON_DESCR_MODULES = json.dumps({"modules": modules}).encode("utf-8")
+DO_DICT = {
+    'sync_en': False, 'trg': [{'count_threshold': 1, 'threshold_invert': False}] * 15
+}
+ADC_DICT = [
+            {
+                "demod": {"en": False},
+                "th_acq": {
+                    "discr_threshold": 0.0,
+                    "non_weighed_integration_len": 1024,
+                    "rotation_matrix_a11": 1.0,
+                    "rotation_matrix_a12": 0.0,
+                },
+                "th_acq_mrk_map": {"addr": 1, "en": False, "inv": False},
+                "th_acq_trg_map": {"addr": 1, "en": False, "inv": False},
+                "ttl": {"auto_bin_incr_en": False, "in": False, "threshold": 0.0},
+            }
+]
+DAC_DICT = [
+    {'cont_mode': {'en_path': [False, False], 'wave_idx_path': [0, 0]}, 'gain_path': [1.0, 1.0],
+     'marker_ovr': {'en': False, 'val': 0},
+     'mixer': {'corr_gain_ratio': 1.0, 'corr_phase_offset_degree': -0.0, 'en': False},
+     'nco': {'delay_comp': 0, 'delay_comp_en': False, 'freq_hz': 0.0, 'po': 0.0},
+     'offs_path': [0.0, 0.0], 'upsample_rate_path': [0, 0]}
+]
+QCM_SEQUENCER_CONFIG = {
+    "awg": DAC_DICT,
+    "seq_proc": DO_DICT
+}
+QRM_SEQUENCER_CONFIG = copy.deepcopy(QCM_SEQUENCER_CONFIG)
+QRM_SEQUENCER_CONFIG.update(dict(acq=ADC_DICT))
+QTM_SEQUENCER_CONFIG = {
+    "seq_proc": DO_DICT
+}
+IO_CHANNEL_CONFIG = {
+    "binned_acq_on_invalid_time_delta": "error",
+    "binned_acq_threshold_source": "thresh0",
+    "binned_acq_time_ref": "start",
+    "binned_acq_time_source": "first",
+    "in_counter_mode": "sequencer",
+    "in_threshold_primary": 1.0,
+    "in_trigger_address": 1,
+    "in_trigger_en": False,
+    "in_trigger_mode": "rising",
+    "out_mode": "disabled",
+    "scope_mode": "scope",
+    "scope_trigger_level": "any",
+    "scope_trigger_mode": "sequencer",
+    "thresholded_acq_trigger_address_high": 0,
+    "thresholded_acq_trigger_address_invalid": 0,
+    "thresholded_acq_trigger_address_low": 0,
+    "thresholded_acq_trigger_address_mid": 0,
+    "thresholded_acq_trigger_en": False,
+}
+
+
+def make_flexible_mock(return_for_getpeername):
+    class FlexibleMock(unittest.mock.MagicMock):
+        def __getattr__(self, name):
+            if name == "getpeername":
+                m = unittest.mock.MagicMock()
+                m.return_value = return_for_getpeername
+                return m
+            return super().__getattr__(name)
+
+    return FlexibleMock("qblox_instruments.native.cluster.IpTransport")
+
+
+class TypeHandle_QbloxModule(_QbloxModule):
+    """Extended class for more complex module function"""
+
+    class InstrumentType:
+        def __init__(self, instr_type: str, is_rf: bool):
+            self.value = instr_type
+
+    def __init__(self, module: str, is_rf: bool):
+        self.instrument_type = self.InstrumentType(module, is_rf)
+        self.is_rf_type = is_rf
+        super().__init__(module, {})
+
+
+class ScpiClusterStub:
+    """Mock the ScpiCluster class"""
+    def __init__(self): ...
+    def _arm_sequencer(self): ...
+    def _start_sequencer(self): ...
+    def _stop_sequencer(self): ...
+
+
+class CreateClusterTestCase(unittest.TestCase):
+    """Test creating cluster instances and see that they are initialized as expected."""
+
+    def _add_is_functions_to_module(self, mod, mod_e):
+        types = ["mm", "qcm", "qrm", "qtm", "rf"]
+        for mod_type in types:
+            setattr(mod, f"is_{mod_type}_type", lambda: mod_type.upper() in mod_e)
+        #     if "QCM" in mod_e and not "RF" in mod_e:
+        #         func_refs.QCM[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
+        #     elif "QRM" in mod_e and not "RF" in mod_e:
+        #         func_refs.QRM[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
+        #     elif "QTM" in mod_e:
+        #         func_refs.QTM[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
+        #     elif "QCM" in mod_e and "RF" in mod_e:
+        #         func_refs.QCM_RF[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
+        #     elif "QRM" in mod_e and "RF" in mod_e:
+        #         func_refs.QRM_RF[f"is_{mod_type}_type"] = lambda: mod_type.upper() in mod_e
+
+        return mod
+
+    def setUp(self) -> None:
+        self._ctx = QMI_Context("cluster_test")
+        self._qblox_instruments_patch = patch("qmi.instruments.qblox.cluster.qblox_instruments", unittest.mock.Mock())
+        self._qblox_instruments_patch.start()
+        self.addCleanup(self._qblox_instruments_patch.stop)
+        # _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
+        # self._scpi_transport = patch("qmi.instruments.qblox.cluster.qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport)
+        # self._read_bin_patch = patch("qmi.instruments.qblox.cluster.qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
+        # self._scpi_transport.start()
+        # self._read_bin_patch.start()
+        self._scpi_cluster_patch = patch("qmi.instruments.qblox.cluster.ScpiCluster", ScpiClusterStub)
+        self._scpi_cluster_patch.start()
+        self.addCleanup(self._scpi_cluster_patch.stop)
+        self._attr_names_patch = patch("qmi.instruments.qblox.cluster._get_required_qrm_qcm_attr_names", return_value=[])
+        self._qtm_attr_names_patch = patch("qmi.instruments.qblox.cluster._get_required_qtm_attr_names", return_value=[])
+        self._attr_names_patch.start()
+        self._qtm_attr_names_patch.start()
+        self.addCleanup(self._attr_names_patch.stop)
+        self.addCleanup(self._qtm_attr_names_patch.stop)
+        self._mod_handles = {}
+        for slot, module in modules.items():
+            module_name = module["model"][8:]
+            is_rf = module["is_rf"]
+            self._mod_handles[slot] = {"type_handle": TypeHandle_QbloxModule(module_name, is_rf)}
+
+    def tearDown(self) -> None:
+        # self._read_bin_patch.stop()
+        # self._scpi_transport.stop()
+        pass
+
+    def test_create_native_cluster(self):
+        # with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch:
+        with patch("qmi.instruments.qblox.cluster.NativeCluster") as cluster_patch:
+            side_effect = ["qblox,Cluster_MM,b," + BUILD_INFO, "0"]
+            cluster_patch().instrument_type = self._mod_handles["0"]["type_handle"].instrument_type
+            cluster_patch()._get_idn = unittest.mock.Mock(side_effect=side_effect)
+            cluster_patch()._mod_handles = self._mod_handles
+            cluster_patch()._type_handle = self._mod_handles["0"]["type_handle"]
+            # side_effect.extend(["0"] * 2 + ["a,Cluster_MM,b," + BUILD_INFO] + ["0"] * 2)
+            # read_patch.side_effect = side_effect
+            # setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
+            # self._read_bin_patch.target._read_bin.side_effect = [MOCK_CLUSTER_LAYOUT] + 2 * [b"0"]
+            name, ip = "native", "123.45.67.89"
+            cluster = Qblox_NativeCluster(self._ctx, name, ip)
+            cluster.open()
+
+        self.assertEqual(name, cluster._name)
+        self.assertEqual("MM", cluster._instrument_type)
+        cluster.close()
+
+    def test_create_qcodes_cluster(self):
+        # Arrange
+        status = unittest.mock.Mock()
+        status.status = "OKAY;NO;PROBLEMS"
+        with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch, patch(
+                "qblox_instruments.scpi.layers.cluster_mm_legacy.Cluster.get_json_description") as json_patch, patch(
+                # "qblox_instruments.scpi.cluster.Cluster.get_json_description") as json_patch, patch(
+                "qblox_instruments.scpi.scpi.Scpi.check_error_queue", autospec=True) as err_patch, patch(
+                # "qblox_instruments.scpi.cluster.Cluster.check_error_queue", autospec=True) as err_patch, patch(
+                "qblox_instruments.native.cluster.Cluster.get_system_status", return_value=status):
+            # side_effect = ["qblox,Cluster MM,b,", "OKAY;NO;PROBLEMS"] + list(map(str, range(20)))
+            side_effect = ["qblox,Cluster MM,b,", "0", "0"] + list(map(str, range(20)))
+            read_patch.side_effect = side_effect
+            # json_patch.side_effect = [JSON_DESCR_MODULES]
+            json_patch.side_effect = [mock_cluster_layout, "0", "0", JSON_DESCR_MODULES]
+            err_patch.return_value = mock_cluster_layout
+            name, ip = "native", "123.45.67.89"
+            # Act
+            cluster = Qblox_QcodesCluster(self._ctx, name, ip)
+            cluster.open()
+
+        # Assert
+        self.assertEqual(name, cluster._name)
+        self.assertEqual("MM", cluster._instrument_type)
+        cluster.close()
+
+
+class NativeClusterTestCase(unittest.TestCase):
+    """Test native cluster instance methods."""
+
+    def setUp(self) -> None:
+        self._read_bin_patch = patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
+        self._read_bin_patch.start()
+        with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as self.read_patch:
+            side_effect = ["qblox,Cluster_MM,b," + BUILD_INFO] * 2
+            side_effect.extend(["0", "0"])
+            self.read_patch.side_effect = side_effect
+            setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
+            self._read_bin_patch.target._read_bin.side_effect = (
+                [JSON_DESCR_MODULES]
+                + [json.dumps(QCM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0, 2], [1, 3]]"] * 12
+                + [json.dumps(QRM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0], [1]]", b"[[0], [1]]"] * 12
+                + [json.dumps(QTM_SEQUENCER_CONFIG).encode("utf-8"), json.dumps(IO_CHANNEL_CONFIG).encode("utf-8")] * 8
+            )
+            name, ip = "native", "123.45.67.89"
+            qmi.instruments.qblox.cluster.DEBUG_LEVEL = 2  # Set to 2 to avoid useless error checks
+            _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
+            with patch("qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport) as self._scpi_transport:
+            # with patch("qblox_instruments.native.cluster.IpTransport", spec=IpTransport) as self._scpi_transport:
+                _ctx = QMI_Context("cluster_test")
+                self.cluster = Qblox_NativeCluster(_ctx, name, ip)
+                self.cluster.open()
+
+    def tearDown(self) -> None:
+        self._read_bin_patch.stop()
+        self.cluster.close()
+
+    def test_get_module(self):
+        mm = self.cluster.get_module("MM")
+        self.assertEqual("Cluster", mm.instrument_class.value)
+        self.assertEqual("MM", mm.instrument_type.value)
+
+        qcm = self.cluster.get_module("QCM")
+        self.assertTrue(qcm.is_qcm_type())
+        self.assertFalse(qcm.is_qrm_type())
+        self.assertFalse(qcm.is_qrc_type())
+        self.assertFalse(qcm.is_qtm_type())
+        self.assertFalse(qcm.is_rf_type())
+
+        qcm_rf = self.cluster.get_module("QCM-RF")
+        self.assertTrue(qcm_rf.is_qcm_type())
+        self.assertFalse(qcm_rf.is_qrm_type())
+        self.assertFalse(qcm.is_qrc_type())
+        self.assertFalse(qcm_rf.is_qtm_type())
+        self.assertTrue(qcm_rf.is_rf_type())
+
+        qrm = self.cluster.get_module("QRM")
+        self.assertFalse(qrm.is_qcm_type())
+        self.assertTrue(qrm.is_qrm_type())
+        self.assertFalse(qcm.is_qrc_type())
+        self.assertFalse(qrm.is_qtm_type())
+        self.assertFalse(qrm.is_rf_type())
+
+        qrm_rf = self.cluster.get_module("QRM-RF")
+        self.assertFalse(qrm_rf.is_qcm_type())
+        self.assertTrue(qrm_rf.is_qrm_type())
+        self.assertFalse(qcm.is_qrc_type())
+        self.assertFalse(qrm_rf.is_qtm_type())
+        self.assertTrue(qrm_rf.is_rf_type())
+
+        qtm = self.cluster.get_module("QTM")
+        self.assertFalse(qtm.is_qcm_type())
+        self.assertFalse(qtm.is_qrm_type())
+        self.assertFalse(qcm.is_qrc_type())
+        self.assertTrue(qtm.is_qtm_type())
+        self.assertFalse(qtm.is_rf_type())
+
+    def test_get_channels(self):
+        """Test getting all channels and sequencers out from the modules"""
+        for module in ["MM", "QCM", "QCM-RF", "QRM", "QRM-RF", "QTM"]:
+            expected_sequencers = SEQUENCERS_IN_MODULE[module]
+            expected_channels = (
+                AO_IN_MODULE[module]
+                + DIGITAL_MARKERS_IN_MODULE[module]
+                + AI_IN_MODULE[module]
+            ) * SEQUENCERS_IN_MODULE[module]
+            if "RF" in module:  # The RF modules are created using the regular non-RF channel map, giving double AIO
+                expected_channels += 2 * SEQUENCERS_IN_MODULE[module]
+
+            if module == "QTM":  # The QTM module has 8 "generic" IO channels in output
+                expected_channels += SEQUENCERS_IN_MODULE[module]
+
+            channels, sequencers = self.cluster.get_module_channels(module)
+            self.assertEqual(expected_channels, len(channels))
+            self.assertEqual(expected_sequencers, len(sequencers))
+
+
+class SequencerObject:
+
+    parameters = IO_CHANNEL_CONFIG
+
+
+class ValString(str):
+    @property
+    def value(self):
+        return str(self)
+
+
+# class TypeHandleWithSetter(TypeHandle):
+# 
+#     def __setattr__(self, par, val):
+#         self.__dict__[f"{par}"] = val
+
+
+class QcodesClusterTestCase(unittest.TestCase):
+    """Test SCPI cluster instance methods."""
+
+    def _add_is_functions_to_module(self, mod, mod_e):
+        types = ["mm", "qcm", "qrm", "qtm", "rf"]
+        for mod_type in types:
+            setattr(mod, f"is_{mod_type}_type", lambda: mod_type.upper() in mod_e)
+
+        return mod
+
+    def setUp(self) -> None:
+        _scpi_transport = make_flexible_mock(("123.45.67.89", "5901"))
+        self._scpi_transport = patch("qblox_instruments.native.cluster.IpTransport", return_value=_scpi_transport)
+        self._scpi_transport.start()
+        self._read_bin_patch = patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read_bin")
+        self._read_bin_patch.start()
+        setattr(self._read_bin_patch.target._read_bin, "__name__", "_read_bin")
+        self._read_bin_patch.target._read_bin.side_effect = (
+            [MOCK_CLUSTER_LAYOUT] + [JSON_DESCR_MODULES]
+            + [json.dumps(QCM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0, 2], [1, 3]]"] * 12
+            + [json.dumps(QRM_SEQUENCER_CONFIG).encode("utf-8"), b"[[0], [1]]", b"[[0], [1]]"] * 12
+            + [json.dumps(QTM_SEQUENCER_CONFIG).encode("utf-8"), json.dumps(IO_CHANNEL_CONFIG).encode("utf-8")] * 8
+        )
+        with patch("qblox_instruments.ieee488_2.ieee488_2.Ieee488_2._read") as read_patch, patch(
+                "qblox_instruments.scpi.layers.cluster_mm_1_0.Cluster.get_json_description") as json_patch, patch(
+                "qblox_instruments.scpi.layers.cluster_mm_1_0.Cluster.check_error_queue", autospec=True
+        ):
+            side_effect = ["a,Cluster MM,b,", "OKAY;NO;PROBLEMS"] + list(map(str, range(20)))
+            read_patch.side_effect = side_effect
+            json_patch.return_value = mock_cluster_layout  # , b"0", b"0", JSON_DESCR_MODULES]
+            name, ip = "skippy", "123.45.67.89"
+            qmi.instruments.qblox.cluster.DEBUG_LEVEL = 2  # Set to 2 to avoid useless error checks
+            _ctx = QMI_Context("cluster_test")
+            with patch("qblox_instruments.native.cluster.Cluster._present_at_init") as present_patch, patch(
+                "qmi.instruments.qblox.cluster.Cluster") as qcodes_patch:
+                modules = ["QCM", "QCM-RF", "QRM", "QRM-RF", "QTM"]
+                # module_handles = [
+                    # TypeHandle(f"CLUSTER_{module}") for module in modules
+                # ]
+                module_handles = [
+                    _QbloxModule(f"CLUSTER_{module}") for module in modules
+                ]
+                # present_patch.side_effect = [module_handles + [TypeHandle("CLUSTER_QDM")] * 14] * 5
+                present_patch.side_effect = [module_handles + [_QbloxModule("CLUSTER_QDM", {})] * 14] * 5
+                # attr_patch.return_value = [
+                #     "is_qrm_type", "is_qtm_type", "is_rf_type", "is_qrc_type", "is_qcm_type"
+                # ]
+                # retval = create_autospec(QcodesCluster, instance=False)
+                # retval.instrument_type = InstrumentType("MM")
+                retval = unittest.mock.MagicMock()
+                retval.instrument_type = _QbloxModule("MM", {})
+                # retval._type_handle = self._add_is_functions_to_module(TypeHandleWithSetter("Cluster_MM"), "MM")
+                retval._type_handle = self._add_is_functions_to_module(unittest.mock.MagicMock("Cluster_MM"), "MM")
+                retval.modules = []
+                for e, mod in enumerate(modules):
+                    # inst_mod = create_autospec(Module)(None, modules[e], e + 1)
+                    inst_mod = create_autospec(_QbloxModule)(modules[e], {})
+                    inst_mod.present = lambda : True
+                    inst_mod.module_type = ValString(modules[e])
+                    inst_mod.slot_idx = e + 1
+                    inst_mod.name = mod
+                    inst_mod.is_mm_type = lambda : False
+                    inst_mod.is_qcm_type = lambda : mod == "QCM"
+                    inst_mod.is_qrm_type = lambda : mod == "QRM"
+                    inst_mod.is_qtm_type = lambda : mod == "QTM"
+                    inst_mod.is_rf_type = lambda : "RF" in mod
+                    retval.modules.append(inst_mod)
+
+                qcodes_patch.return_value = retval
+                self.cluster = Qblox_QcodesCluster(_ctx, name, ip)
+                self.cluster.open()
+
+    def tearDown(self) -> None:
+        self._read_bin_patch.stop()
+        self._scpi_transport.stop()
+        self.cluster.close()
+
+    def test_get_module(self):
+        # TODO: These tests do not run properly. Try to fix!
+        mm = self.cluster.get_module("MM")
+        # self.assertEqual("MM", mm.name)
+        self.assertTrue(mm.is_mm_type)
+
+        qcm = self.cluster.get_module("QCM")
+        self.assertEqual("QCM", qcm.name)
+        self.assertTrue(qcm.is_qcm_type)
+        # self.assertFalse(qcm.is_qrm_type)
+        # self.assertFalse(qcm.is_qtm_type)
+        # self.assertFalse(qcm.is_rf_type)
+
+        qcm_rf = self.cluster.get_module("QCM-RF")
+        self.assertEqual("QCM-RF", qcm_rf.name)
+        self.assertTrue(qcm_rf.is_qcm_type)
+        # self.assertFalse(qcm_rf.is_qrm_type)
+        # self.assertFalse(qcm_rf.is_qtm_type)
+        self.assertTrue(qcm_rf.is_rf_type)
+
+        qrm = self.cluster.get_module("QRM")
+        self.assertEqual("QRM", qrm.name)
+        # self.assertFalse(qrm.is_qcm_type)
+        self.assertTrue(qrm.is_qrm_type)
+        # self.assertFalse(qrm.is_qtm_type)
+        # self.assertFalse(qrm.is_rf_type)
+
+        qrm_rf = self.cluster.get_module("QRM-RF")
+        self.assertEqual("QRM-RF", qrm_rf.name)
+        # self.assertFalse(qrm_rf.is_qcm_type)
+        self.assertTrue(qrm_rf.is_qrm_type)
+        # self.assertFalse(qrm_rf.is_qtm_type)
+        self.assertTrue(qrm_rf.is_rf_type)
+
+        qtm = self.cluster.get_module("QTM")
+        self.assertEqual("QTM", qtm.name)
+        # self.assertFalse(qtm.is_qcm_type)
+        # self.assertFalse(qtm.is_qrm_type)
+        self.assertTrue(qtm.is_qtm_type)
+        # self.assertFalse(qtm.is_rf_type)
+
+    def test_get_module_func_refs(self):
+        # TODO: These tests do not run properly. Try to fix!
+        qcm = self.cluster.get_module_func_refs("QCM")
+        self.assertTrue(qcm["is_qcm_type"]())
+        # self.assertFalse(qcm["is_qrm_type"]())
+        # self.assertFalse(qcm["is_qtm_type"]())
+        # self.assertFalse(qcm["is_rf_type"]())
+
+        qcm_rf = self.cluster.get_module_func_refs("QCM-RF")
+        self.assertTrue(qcm_rf["is_qcm_type"]())
+        # self.assertFalse(qcm_rf["is_qrm_type"]())
+        # self.assertFalse(qcm_rf["is_qtm_type"]())
+        self.assertTrue(qcm_rf["is_rf_type"]())
+
+        qrm = self.cluster.get_module_func_refs("QRM")
+        # self.assertFalse(qrm["is_qcm_type"]())
+        self.assertTrue(qrm["is_qrm_type"]())
+        # self.assertFalse(qrm["is_qtm_type"]())
+        # self.assertFalse(qrm["is_rf_type"]())
+
+        qrm_rf = self.cluster.get_module_func_refs("QRM-RF")
+        # self.assertFalse(qrm_rf["is_qcm_type"]())
+        self.assertTrue(qrm_rf["is_qrm_type"]())
+        # self.assertFalse(qrm_rf["is_qtm_type"]())
+        self.assertTrue(qrm_rf["is_rf_type"]())
+
+        qtm = self.cluster.get_module_func_refs("QTM")
+        # self.assertFalse(qtm["is_qcm_type"]())
+        # self.assertFalse(qtm["is_qrm_type"]())
+        self.assertTrue(qtm["is_qtm_type"]())
+        # self.assertFalse(qtm["is_rf_type"]())
+
+    def test_get_channels(self):
+        """Test getting all channels and sequencers out from the modules"""
+        # NO channels for "MM".
+        with self.assertRaises(ValueError):
+            self.cluster.get_module_channels("MM")
+
+        for e, module in enumerate(["QCM", "QCM-RF", "QRM", "QRM-RF", "QTM"], start=1):
+            # Arrange
+            expected_sequencers = SEQUENCERS_IN_MODULE[module]
+            if module != "QTM":
+                expected_channels = (
+                    AO_IN_MODULE[module]
+                    + DIGITAL_MARKERS_IN_MODULE[module]
+                    + AI_IN_MODULE[module]
+                ) * SEQUENCERS_IN_MODULE[module]
+            # if "RF" in module:  # The RF modules are created using the regular non-RF channel map, giving double AIO
+            #     expected_channels += 2 * SEQUENCERS_IN_MODULE[module]
+            #
+            if module == "QTM":  # The QTM module has 8 "generic" IO channels in output
+                expected_channels = SEQUENCERS_IN_MODULE[module]
+
+            module_mock = self.cluster._modules[str(e)][module]
+            module_mock.sequencers = []
+            num_seq = 6 if module != "QTM" else 8
+            module_mock.io_channels = [f"IO{i}" for i in range(num_seq)] if module == "QTM" else []
+            sequencers_mock = unittest.mock.Mock()
+            sequencers_mock._get_sequencer_config = unittest.mock.Mock(return_value=SequencerObject)
+            for s in range(num_seq):
+                module_mock.sequencers.append(sequencers_mock)
+
+            side_effects = []
+            for seq in range(num_seq):
+                if "QRM" not in module or module != "QTM":
+                    channel_map = [(0, "IQ")] if "RF" in module else [(0, "I"), (1, "Q")]
+                    for path, chn in channel_map:
+                        channels = [0, 2] if not path else [1, 3]
+                        for channel in channels:
+                            side_effects.append([seq, chn, f"dac{channel}"])
+                elif module != "QTM":
+                    for path, chn in [(0, "acq_I"), (1, "acq_Q")]:
+                        channels = [0, 2] if not path else [1, 3]
+                        for channel in channels:
+                            side_effects.append([seq, chn, f"adc{channel}"])
+                else:
+                    for channel in range(8):
+                        side_effects.append([channel, "IQ", f"io{channel}"])
+
+            module_mock._iter_connections = unittest.mock.Mock(side_effect=[side_effects])
+
+            # Act
+            channels, sequencers = self.cluster.get_module_channels(module)
+            # Assert
+            self.assertEqual(expected_channels, len(channels), f"failed for {module}")
+            self.assertEqual(expected_sequencers, len(sequencers))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/instruments/qblox/test_cluster.py
+++ b/tests/instruments/qblox/test_cluster.py
@@ -107,7 +107,7 @@ class TypeHandle_QbloxModule(_QbloxModule):
             self.value = instr_type
 
     class ModuleType:
-        def __init__(self, module_type: str) -> None:
+        def __init__(self, module_type: str, is_rf: bool) -> None:
             self.value = module_type
 
     class InstrumentClass:
@@ -115,15 +115,16 @@ class TypeHandle_QbloxModule(_QbloxModule):
             self.value = "Cluster" if "MM" in instr_type else "Module"
 
     def __init__(self, module: str, is_rf: bool, slot: str) -> None:
+        self.name = module  # Qcodes only
         self.instrument_type = self.InstrumentType(module)
-        self.module_type = self.ModuleType(module)
+        self.module_type = self.ModuleType(module, is_rf)
         self.instrument_class = self.InstrumentClass(module)
         self.is_rf_type = is_rf
-        self.slot_idx = int(slot)
+        self.slot_idx = int(slot)  # Qcodes only
         super().__init__(module, {})
 
     def present(self) -> bool:
-        return True
+        return True  # Qcodes only
     
     def _get_sequencer_config(self, slot: int, sequencer: int) -> dict:
         if "QCM" in modules[str(slot)]["model"]:
@@ -186,7 +187,8 @@ class CreateClusterTestCase(unittest.TestCase):
         for slot, module in modules.items():
             module_name = module["model"][8:]
             is_rf = module["is_rf"]
-            self._mod_handles[slot] = {"type_handle": TypeHandle_QbloxModule(module_name, is_rf, slot)}
+            type_handle = TypeHandle_QbloxModule(module_name, is_rf, slot)
+            self._mod_handles[slot] = {"type_handle": type_handle}
 
     def test_create_native_cluster(self):
         with patch("qmi.instruments.qblox.cluster.NativeCluster") as cluster_patch:
@@ -232,6 +234,42 @@ class CreateClusterTestCase(unittest.TestCase):
             call().clear_sequencer_flags()
         ])
 
+    def test_base_cluster_helpers(self):
+        cluster = qmi.instruments.qblox.cluster.Qblox_ClusterBase(
+            self._ctx, "base", "123.45.67.89", port=5025, dummy_cfg={"1": "QCM"}
+        )
+        cluster._cluster = unittest.mock.Mock()
+        cluster.cluster_funcs["do_work"] = unittest.mock.Mock()
+        status = unittest.mock.Mock()
+        status.status.name = "OKAY"
+        cluster.cluster.get_system_status.return_value = status
+        cluster.cluster.get_trigger_monitor_count.return_value = 7
+        cluster.cluster.get_trigger_monitor_latest.return_value = 3
+
+        self.assertEqual("base", cluster.get_name())
+        self.assertIs(cluster.cluster_funcs, cluster.get_funcs())
+        self.assertEqual("OKAY", cluster.get_system_state())
+        cluster.reset_cluster()
+        cluster.cluster._reset.assert_called_once_with()
+        cluster.reset_trigger_monitor_count(1)
+        cluster.cluster.reset_trigger_monitor_count.assert_called_once_with(1)
+        self.assertEqual(7, cluster.get_trigger_monitor_count(2))
+        cluster.cluster.get_trigger_monitor_count.assert_called_once_with(2)
+        self.assertEqual(3, cluster.get_trigger_monitor_latest())
+
+        with self.assertRaises(ValueError):
+            cluster.reset_trigger_monitor_count(0)
+        with self.assertRaises(ValueError):
+            cluster.get_trigger_monitor_count(16)
+        with self.assertRaises(NotImplementedError):
+            cluster.reset_module(1)
+        with self.assertRaises(NotImplementedError):
+            cluster.get_module("QCM")
+        with self.assertRaises(NotImplementedError):
+            cluster.get_module_func_refs("QCM")
+        with self.assertRaises(NotImplementedError):
+            cluster.get_module_channels("QCM")
+
 
 class NativeClusterTestCase(unittest.TestCase):
     """Test native cluster instance methods."""
@@ -242,8 +280,14 @@ class NativeClusterTestCase(unittest.TestCase):
         for slot, module in modules.items():
             module_name = module["model"][8:]
             is_rf = module["is_rf"]
+            type_handle = TypeHandle_QbloxModule(module_name, is_rf, slot)
+            type_handle._is_mm_type = "MM" in module_name
+            type_handle._is_qcm_type = "QCM" in module_name
+            type_handle._is_qrm_type = "QRM" in module_name
+            type_handle._is_qtm_type = "QTM" in module_name
+            type_handle._is_rf_type = is_rf
             _mod_handles[slot] = {
-                "type_handle": TypeHandle_QbloxModule(module_name, is_rf, slot),
+                "type_handle": type_handle,
                 "_get_sequencer_channel_map": TypeHandle_QbloxModule._get_sequencer_channel_map,
                 "_get_io_channel_config": TypeHandle_QbloxModule._get_io_channel_config
             }
@@ -320,6 +364,86 @@ class NativeClusterTestCase(unittest.TestCase):
         self.assertTrue(qtm.is_qtm_type())
         self.assertFalse(qtm.is_rf_type())
 
+    def test_get_module_func_refs(self):
+        qcm = self.cluster.get_module_func_refs("QCM")
+        self.assertTrue(qcm["is_qcm_type"]())
+        self.assertFalse(qcm["is_qrm_type"]())
+        self.assertFalse(qcm["is_qtm_type"]())
+        self.assertFalse(qcm["is_rf_type"]())
+
+        qcm_rf = self.cluster.get_module_func_refs("QCM-RF")
+        self.assertTrue(qcm_rf["is_qcm_type"]())
+        self.assertFalse(qcm_rf["is_qrm_type"]())
+        self.assertFalse(qcm_rf["is_qtm_type"]())
+        self.assertTrue(qcm_rf["is_rf_type"]())
+
+        qrm = self.cluster.get_module_func_refs("QRM")
+        self.assertFalse(qrm["is_qcm_type"]())
+        self.assertTrue(qrm["is_qrm_type"]())
+        self.assertFalse(qrm["is_qtm_type"]())
+        self.assertFalse(qrm["is_rf_type"]())
+
+        qrm_rf = self.cluster.get_module_func_refs("QRM-RF")
+        self.assertFalse(qrm_rf["is_qcm_type"]())
+        self.assertTrue(qrm_rf["is_qrm_type"]())
+        self.assertFalse(qrm_rf["is_qtm_type"]())
+        self.assertTrue(qrm_rf["is_rf_type"]())
+
+        qtm = self.cluster.get_module_func_refs("QTM")
+        self.assertFalse(qtm["is_qcm_type"]())
+        self.assertFalse(qtm["is_qrm_type"]())
+        self.assertTrue(qtm["is_qtm_type"]())
+        self.assertFalse(qtm["is_rf_type"]())
+
+    def test_get_module_with_slot_and_errors(self):
+        self.assertIs(self.cluster.cluster, self.cluster.get_module("MM", slot_no=0))
+        self.assertEqual("QCM", str(self.cluster.get_module("QCM", slot_no=1)))
+        self.assertEqual("QRM-RF", str(self.cluster.get_module("QRM-RF", slot_no=4)))
+
+        with self.assertRaisesRegex(ValueError, "management module"):
+            self.cluster.get_module("MM", slot_no=1)
+        with self.assertRaisesRegex(ValueError, "slot position 2"):
+            self.cluster.get_module("QCM", slot_no=2)
+        with self.assertRaisesRegex(ValueError, "Module QRC not found"):
+            self.cluster.get_module("QRC")
+
+    def test_get_module_func_refs_for_cluster_and_slot(self):
+        cluster_funcs = self.cluster.get_module_func_refs("MM")
+        self.assertIn("get_trigger_monitor_count", cluster_funcs)
+        self.assertTrue(cluster_funcs["is_mm_type"]())
+
+        qcm_refs = self.cluster.get_module_func_refs("QCM", slot_no=1)
+        self.assertTrue(qcm_refs["is_qcm_type"]())
+        self.assertIn("_get_sequencer_config", qcm_refs)
+
+    def test_native_channel_filters_and_channel_map_cache(self):
+        adc_channels, sequencers = self.cluster.get_module_channels("QRM", slot_no=3, channel_type=1)
+        self.assertEqual(2 * SEQUENCERS_IN_MODULE["QRM"], len(adc_channels))
+        self.assertEqual(SEQUENCERS_IN_MODULE["QRM"], len(sequencers))
+        self.assertTrue(all(name.startswith("adc") for name in adc_channels))
+
+        dac_channels, _ = self.cluster.get_module_channels("QCM", slot_no=1, channel_type=2)
+        self.assertEqual(4 * SEQUENCERS_IN_MODULE["QCM"], len(dac_channels))
+        self.assertTrue(all(name.startswith("dac") for name in dac_channels))
+
+        marker_channels, _ = self.cluster.get_module_channels("QCM", slot_no=1, channel_type=3)
+        self.assertEqual(DIGITAL_MARKERS_IN_MODULE["QCM"] * SEQUENCERS_IN_MODULE["QCM"], len(marker_channels))
+        self.assertTrue(all(name.startswith("DO") for name in marker_channels))
+
+        io_channels, _ = self.cluster.get_module_channels("QTM", slot_no=5, channel_type=4)
+        self.assertEqual(SEQUENCERS_IN_MODULE["QTM"], len(io_channels))
+        self.assertTrue(all(name.startswith("IO") for name in io_channels))
+
+        with patch("qmi.instruments.qblox.cluster.ChannelMapCache", return_value="cache") as cache_patch:
+            cache = self.cluster.get_module_channel_map_cache("QCM", slot_no=1)
+
+        self.assertEqual("cache", cache)
+        cache_patch.assert_called_once()
+
+    def test_reset_module_calls_native_slot_reset(self):
+        self.cluster.reset_module(1)
+        self.cluster.cluster._slot_reset.assert_called_once_with()
+
     def test_get_channels(self):
         """Test getting all channels and sequencers out from the modules"""
         for module in ["MM", "QCM", "QCM-RF", "QRM", "QRM-RF", "QTM"]:
@@ -372,30 +496,23 @@ class QcodesClusterTestCase(unittest.TestCase):
             name, ip = "skippy", "123.45.67.89"
             qmi.instruments.qblox.cluster.DEBUG_LEVEL = 2  # Set to 2 to avoid useless error checks
             _ctx = QMI_Context("cluster_test")
-            modules = ["QCM", "QCM-RF", "QRM", "QRM-RF", "QTM"]
             retval = unittest.mock.MagicMock()
             retval.instrument_type = TypeHandle_QbloxModule("MM", False, 0).instrument_type
             retval._type_handle = self._add_is_functions_to_module(unittest.mock.MagicMock("Cluster_MM"), "MM")
-            retval.modules = []
-            for e, mod in enumerate(modules):
-                is_rf = True if "RF" in mod else False
-                inst_mod = TypeHandle_QbloxModule(mod, is_rf, e)
+            retval_modules = []
+            for e, mod in modules.items():
+                model = mod["model"][8:] + "-RF" if mod["is_rf"] else mod["model"][8:]
+                is_rf = True if "RF" in model else False
+                inst_mod = TypeHandle_QbloxModule(model, is_rf, e)
                 inst_mod.present = lambda : True
-                inst_mod.module_type = ValString(modules[e])
-                inst_mod.slot_idx = e + 1
-                inst_mod.name = mod
-                # inst_mod.is_mm_type = lambda : False
-                # inst_mod.is_qcm_type = lambda : mod == "QCM"
-                # inst_mod.is_qrm_type = lambda : mod == "QRM"
-                # inst_mod.is_qtm_type = lambda : mod == "QTM"
-                # inst_mod.is_rf_type = lambda : "RF" in mod
-                inst_mod.is_mm_type = False
-                inst_mod.is_qcm_type = "QCM" in mod
-                inst_mod.is_qrm_type = "QRM" in mod
-                inst_mod.is_qtm_type = mod == "QTM"
-                # inst_mod.is_rf_type = "RF" in mod
-                retval.modules.append(inst_mod)
+                inst_mod.module_type = ValString(model)
+                inst_mod.is_mm_type = "MM" in model
+                inst_mod.is_qcm_type = "QCM" in model
+                inst_mod.is_qrm_type = "QRM" in model
+                inst_mod.is_qtm_type = model == "QTM"
+                retval_modules.append(inst_mod)
 
+            retval.modules = retval_modules[1:] + [retval_modules.pop(0)]
             cluster_patch.return_value = retval
             self.cluster = Qblox_QcodesCluster(_ctx, name, ip)
             self.cluster.open()
@@ -404,10 +521,12 @@ class QcodesClusterTestCase(unittest.TestCase):
         self.cluster.close()
 
     def test_get_module(self):
-        # TODO: These tests do not run properly. Try to fix!
         mm = self.cluster.get_module("MM")
-        # self.assertEqual("MM", mm.name)
         self.assertTrue(mm.is_mm_type)
+        self.assertFalse(mm.is_qcm_type)
+        self.assertFalse(mm.is_qrm_type)
+        self.assertFalse(mm.is_qtm_type)
+        self.assertFalse(mm.is_rf_type)
 
         qcm = self.cluster.get_module("QCM")
         self.assertEqual("QCM", qcm.name)
@@ -445,7 +564,6 @@ class QcodesClusterTestCase(unittest.TestCase):
         self.assertFalse(qtm.is_rf_type)
 
     def test_get_module_func_refs(self):
-        # TODO: These tests do not run properly. Try to fix!
         qcm = self.cluster.get_module_func_refs("QCM")
         self.assertTrue(qcm["is_qcm_type"]())
         self.assertFalse(qcm["is_qrm_type"]())
@@ -475,6 +593,98 @@ class QcodesClusterTestCase(unittest.TestCase):
         self.assertFalse(qtm["is_qrm_type"]())
         self.assertTrue(qtm["is_qtm_type"]())
         self.assertFalse(qtm["is_rf_type"]())
+
+    def test_get_module_with_slot_and_errors(self):
+        self.assertTrue(self.cluster.get_module("MM", slot_no=0).is_mm_type)
+        self.assertEqual("QCM", self.cluster.get_module("QCM", slot_no=1).name)
+        self.assertEqual("QRM-RF", self.cluster.get_module("QRM-RF", slot_no=4).name)
+
+        with self.assertRaisesRegex(ValueError, "management module"):
+            self.cluster.get_module("MM", slot_no=1)
+        with self.assertRaisesRegex(ValueError, "Module QRC not found"):
+            self.cluster.get_module("QRC")
+        with self.assertRaisesRegex(ValueError, "slot position 2"):
+            self.cluster.get_module_channels("QCM", slot_no=2)
+        with self.assertRaisesRegex(ValueError, "not found on cluster"):
+            self.cluster.get_module_channels("QRC")
+        with self.assertRaisesRegex(ValueError, "slot 0"):
+            self.cluster.get_module_channels("QCM", slot_no=0)
+
+    def test_get_module_func_refs_does_not_mutate_module_type_flags(self):
+        module = self.cluster.get_module("QCM")
+        self.assertIs(module.is_qrm_type, False)
+
+        refs = self.cluster.get_module_func_refs("QCM")
+
+        self.assertIs(module.is_qrm_type, False)
+        self.assertIs(refs["is_qrm_type"](), False)
+        self.assertTrue(callable(refs["is_qrm_type"]))
+
+    def test_get_module_func_refs_for_mm_and_slot(self):
+        with self.assertRaises(AttributeError):
+            self.cluster.get_module_func_refs("MM")
+
+        qrm_rf_refs = self.cluster.get_module_func_refs("QRM-RF", slot_no=4)
+        self.assertTrue(qrm_rf_refs["is_qrm_type"]())
+        self.assertTrue(qrm_rf_refs["is_rf_type"]())
+        self.assertIn("_check_error_queue", qrm_rf_refs)
+
+    def test_check_error_queue_no_errors_and_raises(self):
+        self.cluster.cluster._debug.value = 1
+        self.cluster.cluster._read.side_effect = ["0"]
+        self.cluster._check_error_queue()
+        self.cluster.cluster._read.assert_called_once_with("SYSTem:ERRor:COUNt?")
+
+        self.cluster.cluster._read.reset_mock()
+        self.cluster.cluster._read.side_effect = ["1", "100,first error", "0"]
+        with self.assertRaisesRegex(RuntimeError, "first error"):
+            self.cluster._check_error_queue()
+
+        self.cluster.cluster._read.reset_mock()
+        self.cluster.cluster._read.side_effect = ["0"]
+        with self.assertRaisesRegex(ValueError, "bad value"):
+            self.cluster._check_error_queue(ValueError("bad value"))
+
+    def test_qcodes_channel_filters_and_runtime_fallback(self):
+        qcm = self.cluster._modules["1"]["QCM"]
+        qcm.sequencers = [unittest.mock.Mock(parameters=IO_CHANNEL_CONFIG, sync_en=False) for _ in range(2)]
+        for sequencer in qcm.sequencers:
+            sequencer._get_sequencer_config.return_value = SequencerObject
+        qcm._iter_connections = unittest.mock.Mock(return_value=[
+            [0, "I", "dac0"],
+            [0, "Q", "dac1"],
+            [1, "I", "dac2"],
+            [1, "Q", "dac3"],
+        ])
+
+        dac_channels, sequencers = self.cluster.get_module_channels("QCM", slot_no=1, channel_type=2)
+        self.assertEqual(["dac0_I0", "dac1_Q0", "dac2_I1", "dac3_Q1"], list(dac_channels))
+        self.assertEqual(["sequencer0", "sequencer1"], list(sequencers))
+
+        marker_channels, _ = self.cluster.get_module_channels("QCM", slot_no=1, channel_type=3)
+        self.assertEqual(["DO0_0", "DO1_0", "DO2_1", "DO3_1"], list(marker_channels))
+
+        qtm = self.cluster._modules["5"]["QTM"]
+        qtm.io_channels = []
+        qtm._iter_connections = unittest.mock.Mock(side_effect=RuntimeError("no seq chan"))
+
+        class SequencerStub:
+            sync_en = True
+
+            def _get_sequencer_config(self):
+                return SequencerObject
+
+            def __getattr__(self, name):
+                if name.endswith("_count_threshold"):
+                    return 12
+                if name.endswith("_threshold_invert"):
+                    return False
+                raise AttributeError(name)
+
+        qtm.sequencers = [SequencerStub(), SequencerStub()]
+        fallback_channels, fallback_sequencers = self.cluster.get_module_channels("QTM", slot_no=5, channel_type=3)
+        self.assertEqual(8, len(fallback_channels))
+        self.assertEqual(["sequencer0", "sequencer1"], list(fallback_sequencers))
 
     def test_get_channels(self):
         """Test getting all channels and sequencers out from the modules"""


### PR DESCRIPTION
Add a QMI driver for Qblox Cluster series device. 

The driver contains only base functions to control the cluster, and trigger channels, and receive system info and module | function reference objects.
